### PR TITLE
minor cleanup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,4 @@
 
 ---
 
-* [ ] I have seen and agree to [`CONTRIBUTING.md`](https://github.com/flashbots/suave-geth/blob/main/suave/CONTRIBUTING.md)
+* [ ] I have seen and agree to CONTRIBUTING.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Checks
 
 on:
   push:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ env:
 jobs:
 
   lint:
-    name: Lint
+    name: Lint and test
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -29,6 +29,9 @@ jobs:
 
       - name: Lint
         run: make lint
+
+      - name: Test
+        run: go test ./cmd/geth ./core ./core/types ./core/vm ./eth/... ./internal/ethapi/... ./les/... ./miner ./params ./suave/...
 
       - name: Ensure go mod tidy runs without changes
         run: |
@@ -50,8 +53,5 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Test
-      run: go test ./cmd/geth  ./core ./core/types ./core/vm ./eth/... ./internal/ethapi/... ./les/... ./miner ./params ./suave/...
-
     - name: Build
-      run: make geth 
+      run: make geth

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SUAVE
 
 [![Goreport status](https://goreportcard.com/badge/github.com/flashbots/suave-geth)](https://goreportcard.com/report/github.com/flashbots/suave-geth)
-[![CI status](https://github.com/flashbots/suave-geth/workflows/Go/badge.svg?branch=main)](https://github.com/flashbots/suave-geth/actions?query=workflow%3A%Go%22)
+[![CI status](https://github.com/flashbots/suave-geth/workflows/Go/badge.svg?branch=main)](https://github.com/flashbots/suave-geth/actions/workflows/go.yml)
 
 [SUAVE](https://writings.flashbots.net/mevm-suave-centauri-and-beyond) is designed to decentralize the MEV supply chain by enabling centralized infrastructure (builders, relays, centralized RFQ routing, etc.) to be programmed as smart contracts on a decentralized blockchain.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SUAVE
 
 [![Goreport status](https://goreportcard.com/badge/github.com/flashbots/suave-geth)](https://goreportcard.com/report/github.com/flashbots/suave-geth)
-[![CI status](https://github.com/flashbots/suave-geth/workflows/Go/badge.svg?branch=main)](https://github.com/flashbots/suave-geth/actions/workflows/go.yml)
+[![CI status](https://github.com/flashbots/suave-geth/workflows/Checks/badge.svg?branch=main)](https://github.com/flashbots/suave-geth/actions/workflows/checks.yml)
 
 [SUAVE](https://writings.flashbots.net/mevm-suave-centauri-and-beyond) is designed to decentralize the MEV supply chain by enabling centralized infrastructure (builders, relays, centralized RFQ routing, etc.) to be programmed as smart contracts on a decentralized blockchain.
 


### PR DESCRIPTION
## 📝 Summary

Minor cleanup, 

- move CI tests to "lint and test" step instead of build step
- fix readme CI badge link
- cleanup the PR template because markdown link is looking bad and unhelpful, let's stick to the template we use in the other repos

<img width="919" alt="Screenshot 2023-08-11 at 20 01 41" src="https://github.com/flashbots/suave-geth/assets/116939/cf78151a-3a96-4dbc-82d0-7f6df8abf65d">

- Also renamed CI step from 'Go' to 'Checks' because it's more clear in the badge

<img width="294" alt="Screenshot 2023-08-11 at 20 37 51" src="https://github.com/flashbots/suave-geth/assets/116939/dbee23b8-1a76-4358-998c-a406d89b95a8">

