### PR TITLE
Remove errors join

### DIFF
--- a/suave/cmd/suavecli/main.go
+++ b/suave/cmd/suavecli/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/ecdsa"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -98,16 +97,16 @@ func unwrapPeekerError(rpcErr error) error {
 	}
 	decodedError, err := hexutil.Decode(rpcErr.Error()[20:])
 	if err != nil {
-		return errors.Join(rpcErr, err)
+		return fmt.Errorf("%s: %s", rpcErr, err)
 	}
 
 	unpacked, err := suaveLibAbi.Errors["PeekerReverted"].Inputs.Unpack(decodedError[4:])
 	if err != nil {
-		return errors.Join(rpcErr, err)
+		return fmt.Errorf("%s: %s", rpcErr, err)
 	}
 
 	revertReason := string(unpacked[1].([]byte))
-	return errors.Join(rpcErr, fmt.Errorf("revert reason: %s", revertReason))
+	return fmt.Errorf("%s: %s", rpcErr, fmt.Errorf("revert reason: %s", revertReason))
 }
 
 func waitForTransactionToBeConfirmed(suaveClient *rpc.Client, txHash *common.Hash) {


### PR DESCRIPTION
## 📝 Summary

`errors.Join` function was included in Go `1.20` but the `go.mod` file uses `1.19` version so it throws an error when running `suavecli`.  

---

* [x] I have seen and agree to CONTRIBUTING.md
