### PR TITLE
Fix incorrect hyperlinks in readme

### DIFF
--- a/suave/cmd/suavecli/README.md
+++ b/suave/cmd/suavecli/README.md
@@ -66,15 +66,14 @@ For example:
 
 To get a better understanding of how the MEVM works, let's delve into the deployment of a simple version of `[mev-share](https://github.com/flashbots/mev-share)`, a protocol for orderflow auctions, defined via smart contract on SUAVE. Our journey below will guide you through the steps of deploying simple mev-share and block builder contracts, interacting with them, and ultimately seeing a block land onchain.
 
-- [Intro](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#Intro)
-- [Prerequisites 🛠](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#Prerequisites-%F0%9F%9B%A0)
-- [Walkthrough Overview 🚀](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#Walkthrough-Overview-%F0%9F%9A%80)
-    - [1. Deploy Simple MEV-Share Contract 📜](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#1-Deploy-Simple-MEV-Share-Contract-%F0%9F%93%9C)
-    - [2. Deploy Block Builder Contract 📜](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#2-Deploy-Block-Builder-Contract-%F0%9F%93%9C)
-    - [3. Send Mevshare Bundles 📨](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#3-Send-Mevshare-Bundles-%F0%9F%93%A8)
-    - [4. Send Mevshare Matches 🎯](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#4-Send-Mevshare-Matches-%F0%9F%8E%AF)
-    - [5. Build Block and Relay 🧱](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#5-Build-Block-and-Relay-%F0%9F%A7%B1)
-- [Conclusion 🎓](https://hackmd.io/5BMLvHO8RnaUUN8Tv165XA#Conclusion-%F0%9F%8E%93)
+- [Intro](#simple-mev-share-walkthrough)
+- [Prerequisites 🛠](#prerequisites-)
+- [Walkthrough Overview 🚀](#walkthrough-overview-)
+    - [1. Deploy Simple MEV-Share Contract 📜](#1-deploy-simple-mev-share-contract-)
+    - [2. Deploy Block Builder Contract 📜](#2-deploy-block-builder-contract-)
+    - [3. Send Mevshare Bundles 📨](#3-send-mevshare-bundles-)
+    - [4. Send Mevshare Matches 🎯](#4-send-mevshare-matches-)
+    - [5. Build Block and Relay 🧱](#5-build-block-and-relay-)
 
 ## Prerequisites 🛠
 


### PR DESCRIPTION
## 📝 Summary

The hyperlinks in the README link to a private hack.md page.

There is also no conclusion, so I deleted that from the table of contents.
