### PR TITLE
Adds suave_dev dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 */**/*tx_database*
 */**/*dapps*
 build/_vendor/pkg
+suave_dev
 
 #*
 .#*

--- a/suave/devenv/docker-compose.yml
+++ b/suave/devenv/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.3"
 
 services:
   suave-mevm:


### PR DESCRIPTION
## 📝 Summary

The `suave_dev` dir is created when running binaries according to our new instructions. Probably best to ignore it.


* [x] I have seen and agree to CONTRIBUTING.md
