### PR TITLE
Adds suave_dev dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 */**/*tx_database*
 */**/*dapps*
 build/_vendor/pkg
+suave_dev
 
 #*
 .#*


### PR DESCRIPTION
## 📝 Summary

This directory is created in our new instructions when running binaries locally. Prob best to ignore it.

* [x] I have seen and agree to CONTRIBUTING.md
