### PR TITLE
Do not dereference big.Int in abi

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,7 +44,7 @@ jobs:
         run: make lint
 
       - name: Test
-        run: go test ./cmd/geth ./core ./core/types ./core/vm ./eth/... ./internal/ethapi/... ./les/... ./miner ./params ./suave/...
+        run: go test ./accounts ./cmd/geth ./core ./core/types ./core/vm ./eth/... ./internal/ethapi/... ./les/... ./miner ./params ./suave/...
 
       - name: Ensure go mod tidy runs without changes
         run: |

--- a/accounts/abi/error_handling.go
+++ b/accounts/abi/error_handling.go
@@ -19,6 +19,7 @@ package abi
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
 )
 
@@ -43,6 +44,8 @@ func formatSliceString(kind reflect.Kind, sliceSize int) string {
 	return fmt.Sprintf("[%d]%v", sliceSize, kind)
 }
 
+var bigIntTyp = reflect.TypeOf(new(big.Int))
+
 // sliceTypeCheck checks that the given slice can by assigned to the reflection
 // type in t.
 func sliceTypeCheck(t Type, val reflect.Value) error {
@@ -61,8 +64,8 @@ func sliceTypeCheck(t Type, val reflect.Value) error {
 	}
 
 	innerTyp := val.Type().Elem()
-	if innerTyp.Kind() == reflect.Ptr {
-		// if the inner value is a pointer, dereference it
+	if innerTyp.Kind() == reflect.Ptr && innerTyp != bigIntTyp {
+		// if the inner value is a pointer and not a big int, dereference it
 		innerTyp = innerTyp.Elem()
 	}
 


### PR DESCRIPTION
## 📝 Summary

This PR fixes a bug introduced in #10 in the abi decoder where big.Int pointers were being dereferenced before abi unpacking.

---

* [x] I have seen and agree to CONTRIBUTING.md
