### PR TITLE
Cli utility to send a full mev-share workflow on devenv

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,3 +67,22 @@ jobs:
 
       - name: Build
         run: make geth
+
+  devenv:
+    name: Devenv
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.20
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run dev environment
+        run: make devnet-up
+
+      - name: Run mev-share example
+        run: go run suave/devenv/cmd/main.go

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ devtools:
 	@type "protoc" 2> /dev/null || echo 'Please install protoc'
 
 devnet-up:
-	docker-compose -f ./suave/devenv/docker-compose.yml up -d
+	docker-compose -f ./suave/devenv/docker-compose.yml up -d --build
 
 devnet-down:
 	docker-compose -f ./suave/devenv/docker-compose.yml down

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -621,6 +621,7 @@ func DeveloperGenesisBlock(period uint64, gasLimit uint64, faucet common.Address
 			common.HexToAddress("0x4f91862699aF93251B3e3518E4Ca627803689252"): {Balance: new(big.Int).Mul(big.NewInt(1000000000000000000), big.NewInt(10000000000))}, // initial signer
 			common.HexToAddress("0x71B21E9b8029d1E384B71B2A1708005A7d4D0428"): {Balance: new(big.Int).Mul(big.NewInt(1000000000000000000), big.NewInt(10000000000))},
 			common.HexToAddress("0xfB8CcAb59b2d3Ef32B966F26891842db2b35d787"): {Balance: new(big.Int).Mul(big.NewInt(1000000000000000000), big.NewInt(10000000000))},
+			common.HexToAddress("0xBE69d72ca5f88aCba033a063dF5DBe43a4148De0"): {Balance: new(big.Int).Mul(big.NewInt(1000000000000000000), big.NewInt(10000000000))},
 			faucet: {Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))},
 		},
 	}

--- a/suave/devenv/cmd/main.go
+++ b/suave/devenv/cmd/main.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+
+	_ "embed"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/suave/e2e"
+	"github.com/ethereum/go-ethereum/suave/sdk"
+)
+
+var (
+	exNodeEthAddr = common.HexToAddress("b5feafbdd752ad52afb7e1bd2e40432a485bbb7f")
+	exNodeNetAddr = "http://localhost:8545"
+
+	// This account is funded in both devnev networks
+	// address: 0xBE69d72ca5f88aCba033a063dF5DBe43a4148De0
+	fundedAccount = newPrivKeyFromHex("91ab9a7e53c220e6210460b65a7a3bb2ca181412a8a7b43ff336b3df1737ce12")
+)
+
+var (
+	bundleBidContract = e2e.BundleBidContract
+	mevShareArtifact  = e2e.MevShareBidContract
+)
+
+func main() {
+	rpc, _ := rpc.Dial(exNodeNetAddr)
+	mevmClt := sdk.NewClient(rpc, fundedAccount.priv, exNodeEthAddr)
+
+	var mevShareContract *sdk.Contract
+	_ = mevShareContract
+
+	var (
+		testAddr1 *privKey
+		testAddr2 *privKey
+	)
+
+	var (
+		ethTxn1       *types.Transaction
+		ethTxnBackrun *types.Transaction
+	)
+
+	fundBalance := big.NewInt(100000000)
+	var bidId [16]byte
+
+	steps := []step{
+		{
+			name: "Create and fund test accounts",
+			action: func() error {
+				testAddr1 = generatePrivKey()
+				testAddr2 = generatePrivKey()
+
+				if err := fundAccount(mevmClt, testAddr1.Address(), fundBalance); err != nil {
+					return err
+				}
+				fmt.Printf("- Funded test account: %s (%s)\n", testAddr1.Address().Hex(), fundBalance.String())
+
+				// craft mev transactions
+
+				// we use the sdk.Client for the Sign function though we only
+				// want to sign simple ethereum transactions and not compute requests
+				cltAcct1 := sdk.NewClient(rpc, testAddr1.priv, common.Address{})
+				cltAcct2 := sdk.NewClient(rpc, testAddr2.priv, common.Address{})
+
+				targeAddr := testAddr1.Address()
+
+				ethTxn1, _ = cltAcct1.SignTxn(&types.LegacyTx{
+					To:       &targeAddr,
+					Value:    big.NewInt(1000),
+					Gas:      21000,
+					GasPrice: big.NewInt(13),
+				})
+
+				ethTxnBackrun, _ = cltAcct2.SignTxn(&types.LegacyTx{
+					To:       &targeAddr,
+					Value:    big.NewInt(1000),
+					Gas:      21420,
+					GasPrice: big.NewInt(13),
+				})
+				return nil
+			},
+		},
+		{
+			name: "Deploy mev-share contract",
+			action: func() error {
+				txnResult, err := sdk.DeployContract(mevShareArtifact.Code, mevmClt)
+				if err != nil {
+					return err
+				}
+				receipt, err := txnResult.Wait()
+				if err != nil {
+					return err
+				}
+				if receipt.Status == 0 {
+					return fmt.Errorf("failed to deploy contract")
+				}
+
+				fmt.Printf("- Mev share contract deployed: %s\n", receipt.ContractAddress)
+				mevShareContract = sdk.GetContract(receipt.ContractAddress, mevShareArtifact.Abi, mevmClt)
+				return nil
+			},
+		},
+		{
+			name: "Send bid",
+			action: func() error {
+				bundle := types.SBundle{
+					Txs:             types.Transactions{ethTxn1},
+					RevertingHashes: []common.Hash{},
+					RefundPercent:   10,
+				}
+				bundleBytes, _ := json.Marshal(bundle)
+
+				// new bid inputs
+				targetBlock := uint64(1)
+				allowedPeekers := []common.Address{mevShareContract.Address()}
+
+				confidentialDataBytes, _ := bundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
+
+				txnResult, err := mevShareContract.SendTransaction("newBid", []interface{}{targetBlock + 1, allowedPeekers}, confidentialDataBytes)
+				if err != nil {
+					return err
+				}
+				receipt, err := txnResult.Wait()
+				if err != nil {
+					return err
+				}
+				if receipt.Status == 0 {
+					return fmt.Errorf("failed to send bid")
+				}
+
+				bidEvent := &BidEvent{}
+				if err := bidEvent.Unpack(receipt.Logs[0]); err != nil {
+					return err
+				}
+				hintEvent := &HintEvent{}
+				if err := hintEvent.Unpack(receipt.Logs[1]); err != nil {
+					return err
+				}
+				bidId = bidEvent.BidId
+
+				fmt.Printf("- Bid sent at txn: %s\n", receipt.TxHash.Hex())
+				fmt.Printf("- Bid id: %x\n", bidEvent.BidId)
+
+				return nil
+			},
+		},
+		{
+			name: "Send backrun",
+			action: func() error {
+				backRunBundle := types.SBundle{
+					Txs:             types.Transactions{ethTxnBackrun},
+					RevertingHashes: []common.Hash{},
+					MatchId:         bidId,
+				}
+				backRunBundleBytes, _ := json.Marshal(backRunBundle)
+
+				confidentialDataMatchBytes, _ := bundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(backRunBundleBytes)
+
+				// backrun inputs
+				targetBlock := uint64(1)
+				allowedPeekers := []common.Address{mevShareContract.Address()}
+
+				txnResult, err := mevShareContract.SendTransaction("newMatch", []interface{}{targetBlock + 1, allowedPeekers, bidId}, confidentialDataMatchBytes)
+				if err != nil {
+					return err
+				}
+				receipt, err := txnResult.Wait()
+				if err != nil {
+					return err
+				}
+				if receipt.Status == 0 {
+					return fmt.Errorf("failed to send bid")
+				}
+
+				bidEvent := &BidEvent{}
+				if err := bidEvent.Unpack(receipt.Logs[0]); err != nil {
+					return err
+				}
+
+				fmt.Printf("- Backrun sent at txn: %s\n", receipt.TxHash.Hex())
+				fmt.Printf("- Backrun bid id: %x\n", bidEvent.BidId)
+
+				return nil
+			},
+		},
+	}
+
+	for indx, step := range steps {
+		fmt.Printf("Step %d: %s\n", indx, step.name)
+		if err := step.action(); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func fundAccount(clt *sdk.Client, to common.Address, value *big.Int) error {
+	txn := &types.LegacyTx{
+		Value: value,
+		To:    &to,
+	}
+	result, err := clt.SendTransaction(txn)
+	if err != nil {
+		return err
+	}
+	_, err = result.Wait()
+	if err != nil {
+		return err
+	}
+	// check balance
+	balance, err := clt.RPC().BalanceAt(context.Background(), to, nil)
+	if err != nil {
+		return err
+	}
+	if balance.Cmp(value) != 0 {
+		return fmt.Errorf("failed to fund account")
+	}
+	return nil
+}
+
+type step struct {
+	name   string
+	action func() error
+}
+
+type privKey struct {
+	priv *ecdsa.PrivateKey
+}
+
+func (p *privKey) Address() common.Address {
+	return crypto.PubkeyToAddress(p.priv.PublicKey)
+}
+
+func (p *privKey) MarshalPrivKey() []byte {
+	return crypto.FromECDSA(p.priv)
+}
+
+func newPrivKeyFromHex(hex string) *privKey {
+	key, err := crypto.HexToECDSA(hex)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse private key: %v", err))
+	}
+	return &privKey{priv: key}
+}
+
+func generatePrivKey() *privKey {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate private key: %v", err))
+	}
+	return &privKey{priv: key}
+}
+
+type HintEvent struct {
+	BidId [16]byte
+	Hint  []byte
+}
+
+func (h *HintEvent) Unpack(log *types.Log) error {
+	unpacked, err := mevShareArtifact.Abi.Events["HintEvent"].Inputs.Unpack(log.Data)
+	if err != nil {
+		return err
+	}
+	h.BidId = unpacked[0].([16]byte)
+	h.Hint = unpacked[1].([]byte)
+	return nil
+}
+
+type BidEvent struct {
+	BidId               [16]byte
+	DecryptionCondition uint64
+	AllowedPeekers      []common.Address
+}
+
+func (b *BidEvent) Unpack(log *types.Log) error {
+	unpacked, err := bundleBidContract.Abi.Events["BidEvent"].Inputs.Unpack(log.Data)
+	if err != nil {
+		return err
+	}
+	b.BidId = unpacked[0].([16]byte)
+	b.DecryptionCondition = unpacked[1].(uint64)
+	b.AllowedPeekers = unpacked[2].([]common.Address)
+	return nil
+}

--- a/suave/devenv/docker-compose.yml
+++ b/suave/devenv/docker-compose.yml
@@ -7,13 +7,18 @@ services:
       - --dev
       - --dev.gaslimit=30000000
       - --http
+      - --http.port=8545
+      - --http.addr=0.0.0.0
+      - --http.vhosts=*
+      - --http.corsdomain=*
       - --ws
+      - --ws.origins=*
+      - --ws.addr=0.0.0.0
       - --datadir=/data
       - --keystore=/keystore/keystore
       - --allow-insecure-unlock
       - --unlock=0xB5fEAfbDD752ad52Afb7e1bD2E40432A485bBB7F
       - --password=/keystore/password.txt
-      - --suave.eth.remote_endpoint=http://localhost:8555
     depends_on:
       - suave-enabled-chain
     volumes:

--- a/suave/e2e/contracts.go
+++ b/suave/e2e/contracts.go
@@ -1,25 +1,35 @@
-package main
+package e2e
 
 import (
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 var (
-	matchBidContract          = newArtifact("bids.sol/MevShareBidContract.json")
-	bundleBidContract         = newArtifact("bids.sol/BundleBidContract.json")
+	MevShareBidContract       = newArtifact("bids.sol/MevShareBidContract.json")
+	BundleBidContract         = newArtifact("bids.sol/BundleBidContract.json")
 	buildEthBlockContract     = newArtifact("bids.sol/EthBlockBidContract.json")
 	ethBlockBidSenderContract = newArtifact("bids.sol/EthBlockBidSenderContract.json")
 	suaveLibContract          = newArtifact("SuaveAbi.sol/SuaveAbi.json")
 )
 
-func newArtifact(name string) *artifact {
-	data, err := os.ReadFile(filepath.Join("../artifacts", name))
+func newArtifact(name string) *Artifact {
+	// Get the caller's file path.
+	_, filename, _, _ := runtime.Caller(1)
+
+	// Resolve the directory of the caller's file.
+	callerDir := filepath.Dir(filename)
+
+	// Construct the absolute path to the target file.
+	targetFilePath := filepath.Join(callerDir, "../artifacts", name)
+
+	data, err := os.ReadFile(targetFilePath)
 	if err != nil {
 		panic(fmt.Sprintf("failed to read artifact %s: %v", name, err))
 	}
@@ -33,14 +43,14 @@ func newArtifact(name string) *artifact {
 		panic(fmt.Sprintf("failed to unmarshal artifact %s: %v", name, err))
 	}
 
-	return &artifact{
+	return &Artifact{
 		Abi:          artifactObj.Abi,
 		Code:         hexutil.MustDecode(artifactObj.Bytecode),
 		DeployedCode: hexutil.MustDecode(artifactObj.DeployedBytecode),
 	}
 }
 
-type artifact struct {
+type Artifact struct {
 	Abi          *abi.ABI
 	DeployedCode []byte
 	Code         []byte

--- a/suave/e2e/workflow_test.go
+++ b/suave/e2e/workflow_test.go
@@ -1,4 +1,4 @@
-package main
+package e2e
 
 import (
 	"context"
@@ -249,10 +249,10 @@ func TestBundleBid(t *testing.T) {
 		bundleBytes, err := json.Marshal(bundle)
 		require.NoError(t, err)
 
-		confidentialDataBytes, err := bundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
+		confidentialDataBytes, err := BundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
 		require.NoError(t, err)
 
-		bundleBidContractI := sdk.GetContract(newBundleBidAddress, bundleBidContract.Abi, clt)
+		bundleBidContractI := sdk.GetContract(newBundleBidAddress, BundleBidContract.Abi, clt)
 		_, err = bundleBidContractI.SendTransaction("newBid", []interface{}{targetBlock, allowedPeekers}, confidentialDataBytes)
 		require.NoError(t, err)
 
@@ -265,7 +265,7 @@ func TestBundleBid(t *testing.T) {
 		require.Equal(t, uint64(1), receipts[0].Status)
 
 		require.Equal(t, 1, len(block.Transactions()))
-		unpacked, err := bundleBidContract.Abi.Methods["emitBid"].Inputs.Unpack(block.Transactions()[0].Data()[4:])
+		unpacked, err := BundleBidContract.Abi.Methods["emitBid"].Inputs.Unpack(block.Transactions()[0].Data()[4:])
 		require.NoError(t, err)
 		bid := unpacked[0].(struct {
 			Id                  [16]uint8        "json:\"id\""
@@ -279,7 +279,7 @@ func TestBundleBid(t *testing.T) {
 		require.NotNil(t, receipts[0].Logs[0])
 		require.Equal(t, newBundleBidAddress, receipts[0].Logs[0].Address)
 
-		unpacked, err = bundleBidContract.Abi.Events["BidEvent"].Inputs.Unpack(receipts[0].Logs[0].Data)
+		unpacked, err = BundleBidContract.Abi.Events["BidEvent"].Inputs.Unpack(receipts[0].Logs[0].Data)
 		require.NoError(t, err)
 
 		require.Equal(t, bid.Id, unpacked[0].([16]byte))
@@ -333,10 +333,10 @@ func TestMevShare(t *testing.T) {
 	allowedPeekers := []common.Address{{0x41, 0x42, 0x43}, newBlockBidAddress, extractHintAddress, buildEthBlockAddress, mevShareAddress}
 
 	// TODO : reusing this function selector from bid contract to avoid creating another ABI
-	confidentialDataBytes, err := bundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
+	confidentialDataBytes, err := BundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
 	require.NoError(t, err)
 
-	bundleBidContractI := sdk.GetContract(mevShareAddress, bundleBidContract.Abi, clt)
+	bundleBidContractI := sdk.GetContract(mevShareAddress, BundleBidContract.Abi, clt)
 	_, err = bundleBidContractI.SendTransaction("newBid", []interface{}{targetBlock + 1, allowedPeekers}, confidentialDataBytes)
 	require.NoError(t, err)
 
@@ -356,7 +356,7 @@ func TestMevShare(t *testing.T) {
 	require.NotEmpty(t, r.Logs)
 
 	// extract share BidId
-	unpacked, err := matchBidContract.Abi.Events["HintEvent"].Inputs.Unpack(r.Logs[1].Data)
+	unpacked, err := MevShareBidContract.Abi.Events["HintEvent"].Inputs.Unpack(r.Logs[1].Data)
 	require.NoError(t, err)
 	shareBidId := unpacked[0].([16]byte)
 
@@ -382,10 +382,10 @@ func TestMevShare(t *testing.T) {
 	// decryption conditions are assumed to be eth blocks right now
 
 	// TODO : reusing this function selector from bid contract to avoid creating another ABI
-	confidentialDataMatchBytes, err := bundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(backRunBundleBytes)
+	confidentialDataMatchBytes, err := BundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(backRunBundleBytes)
 	require.NoError(t, err)
 
-	cc := sdk.GetContract(mevShareAddress, matchBidContract.Abi, clt)
+	cc := sdk.GetContract(mevShareAddress, MevShareBidContract.Abi, clt)
 	_, err = cc.SendTransaction("newMatch", []interface{}{targetBlock + 1, allowedPeekers, shareBidId}, confidentialDataMatchBytes)
 	require.NoError(t, err)
 
@@ -429,7 +429,7 @@ func TestMevShare(t *testing.T) {
 
 		require.Equal(t, 2, len(receipts[0].Logs))
 		require.NotNil(t, receipts[0].Logs[1])
-		unpacked, err := bundleBidContract.Abi.Events["BidEvent"].Inputs.Unpack(receipts[0].Logs[1].Data)
+		unpacked, err := BundleBidContract.Abi.Events["BidEvent"].Inputs.Unpack(receipts[0].Logs[1].Data)
 		require.NoError(t, err)
 
 		bidId := unpacked[0].([16]byte)
@@ -583,10 +583,10 @@ func TestBlockBuildingContract(t *testing.T) {
 	{ // Send a bundle bid
 		allowedPeekers := []common.Address{newBlockBidAddress, newBundleBidAddress, buildEthBlockAddress}
 
-		confidentialDataBytes, err := bundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
+		confidentialDataBytes, err := BundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
 		require.NoError(t, err)
 
-		bundleBidContractI := sdk.GetContract(newBundleBidAddress, bundleBidContract.Abi, clt)
+		bundleBidContractI := sdk.GetContract(newBundleBidAddress, BundleBidContract.Abi, clt)
 
 		_, err = bundleBidContractI.SendTransaction("newBid", []interface{}{targetBlock + 1, allowedPeekers}, confidentialDataBytes)
 		require.NoError(t, err)
@@ -699,10 +699,10 @@ func TestRelayBlockSubmissionContract(t *testing.T) {
 	{ // Send a bundle bid
 		allowedPeekers := []common.Address{ethBlockBidSenderAddr, newBundleBidAddress, buildEthBlockAddress}
 
-		confidentialDataBytes, err := bundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
+		confidentialDataBytes, err := BundleBidContract.Abi.Methods["fetchBidConfidentialBundleData"].Outputs.Pack(bundleBytes)
 		require.NoError(t, err)
 
-		bundleBidContractI := sdk.GetContract(newBundleBidAddress, bundleBidContract.Abi, clt)
+		bundleBidContractI := sdk.GetContract(newBundleBidAddress, BundleBidContract.Abi, clt)
 		_, err = bundleBidContractI.SendTransaction("newBid", []interface{}{targetBlock + 1, allowedPeekers}, confidentialDataBytes)
 		require.NoError(t, err)
 	}
@@ -894,10 +894,10 @@ var (
 		Alloc: core.GenesisAlloc{
 			testAddr:              {Balance: testBalance},
 			testAddr2:             {Balance: testBalance},
-			newBundleBidAddress:   {Balance: big.NewInt(0), Code: bundleBidContract.DeployedCode},
+			newBundleBidAddress:   {Balance: big.NewInt(0), Code: BundleBidContract.DeployedCode},
 			newBlockBidAddress:    {Balance: big.NewInt(0), Code: buildEthBlockContract.DeployedCode},
 			blockBidSenderAddress: {Balance: big.NewInt(0), Code: ethBlockBidSenderContract.DeployedCode},
-			mevShareAddress:       {Balance: big.NewInt(0), Code: matchBidContract.DeployedCode},
+			mevShareAddress:       {Balance: big.NewInt(0), Code: MevShareBidContract.DeployedCode},
 		},
 	}
 

--- a/suave/sdk/sdk.go
+++ b/suave/sdk/sdk.go
@@ -3,8 +3,10 @@ package sdk
 import (
 	"context"
 	"crypto/ecdsa"
-	"math/big"
+	"fmt"
+	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -13,6 +15,13 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 )
+
+func DeployContract(bytecode []byte, client *Client) (*TransactionResult, error) {
+	txn := &types.LegacyTx{
+		Data: bytecode,
+	}
+	return client.SendTransaction(txn)
+}
 
 type Contract struct {
 	addr   common.Address
@@ -29,9 +38,11 @@ func GetContract(addr common.Address, abi *abi.ABI, client *Client) *Contract {
 	return c
 }
 
-func (c *Contract) SendTransaction(method string, args []interface{}, confidentialDataBytes []byte) (*TransactionResult, error) {
-	clt := ethclient.NewClient(c.client.rpc)
+func (c *Contract) Address() common.Address {
+	return c.addr
+}
 
+func (c *Contract) SendTransaction(method string, args []interface{}, confidentialDataBytes []byte) (*TransactionResult, error) {
 	signer, err := c.client.getSigner()
 	if err != nil {
 		return nil, err
@@ -43,7 +54,12 @@ func (c *Contract) SendTransaction(method string, args []interface{}, confidenti
 	}
 
 	senderAddr := crypto.PubkeyToAddress(c.client.key.PublicKey)
-	nonce, err := clt.PendingNonceAt(context.Background(), senderAddr)
+	nonce, err := c.client.rpc.PendingNonceAt(context.Background(), senderAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	gasPrice, err := c.client.rpc.SuggestGasPrice(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +68,8 @@ func (c *Contract) SendTransaction(method string, args []interface{}, confidenti
 		Nonce:    nonce,
 		To:       &c.addr,
 		Value:    nil,
+		GasPrice: gasPrice,
 		Gas:      1000000,
-		GasPrice: big.NewInt(10),
 		Data:     calldata,
 	}
 
@@ -71,18 +87,48 @@ func (c *Contract) SendTransaction(method string, args []interface{}, confidenti
 	}
 
 	var hash common.Hash
-	if err = c.client.rpc.Call(&hash, "eth_sendRawTransaction", hexutil.Encode(computeRequestBytes), hexutil.Encode(confidentialDataBytes)); err != nil {
+	if err = c.client.rpc.Client().Call(&hash, "eth_sendRawTransaction", hexutil.Encode(computeRequestBytes), hexutil.Encode(confidentialDataBytes)); err != nil {
 		return nil, err
 	}
 
 	res := &TransactionResult{
+		clt:  c.client,
 		hash: hash,
 	}
 	return res, nil
 }
 
 type TransactionResult struct {
-	hash common.Hash
+	clt     *Client
+	hash    common.Hash
+	receipt *types.Receipt
+}
+
+func (t *TransactionResult) Wait() (*types.Receipt, error) {
+	if t.receipt != nil {
+		return t.receipt, nil
+	}
+
+	timer := time.NewTimer(10 * time.Second)
+
+	var receipt *types.Receipt
+	var err error
+
+	for {
+		select {
+		case <-timer.C:
+			return nil, fmt.Errorf("timeout")
+		case <-time.After(100 * time.Millisecond):
+			receipt, err = t.clt.rpc.TransactionReceipt(context.Background(), t.hash)
+			if err != nil && err != ethereum.NotFound {
+				return nil, err
+			}
+			if receipt != nil {
+				t.receipt = receipt
+				return t.receipt, nil
+			}
+		}
+	}
 }
 
 func (t *TransactionResult) Hash() common.Hash {
@@ -90,23 +136,26 @@ func (t *TransactionResult) Hash() common.Hash {
 }
 
 type Client struct {
-	rpc      *rpc.Client
+	rpc      *ethclient.Client
 	key      *ecdsa.PrivateKey
 	execNode common.Address
 }
 
 func NewClient(rpc *rpc.Client, key *ecdsa.PrivateKey, execNode common.Address) *Client {
 	c := &Client{
-		rpc:      rpc,
+		rpc:      ethclient.NewClient(rpc),
 		key:      key,
 		execNode: execNode,
 	}
 	return c
 }
 
+func (c *Client) RPC() *ethclient.Client {
+	return c.rpc
+}
+
 func (c *Client) getSigner() (types.Signer, error) {
-	clt := ethclient.NewClient(c.rpc)
-	chainID, err := clt.ChainID(context.TODO())
+	chainID, err := c.rpc.ChainID(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -125,4 +174,60 @@ func (c *Client) SignTxn(txn *types.LegacyTx) (*types.Transaction, error) {
 		return nil, err
 	}
 	return ethTx, nil
+}
+
+func (c *Client) SendTransaction(wrappedTxData *types.LegacyTx) (*TransactionResult, error) {
+	senderAddr := crypto.PubkeyToAddress(c.key.PublicKey)
+
+	if wrappedTxData.Nonce == 0 {
+		nonce, err := c.rpc.PendingNonceAt(context.Background(), senderAddr)
+		if err != nil {
+			return nil, err
+		}
+		wrappedTxData.Nonce = nonce
+	}
+
+	if wrappedTxData.GasPrice == nil {
+		gasPrice, err := c.rpc.SuggestGasPrice(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		wrappedTxData.GasPrice = gasPrice
+	}
+
+	if wrappedTxData.Gas == 0 {
+		estimateMsg := ethereum.CallMsg{
+			From:     senderAddr,
+			To:       wrappedTxData.To,
+			GasPrice: wrappedTxData.GasPrice,
+			Value:    wrappedTxData.Value,
+			Data:     wrappedTxData.Data,
+		}
+		gasLimit, err := c.rpc.EstimateGas(context.Background(), estimateMsg)
+		if err != nil {
+			return nil, err
+		}
+		wrappedTxData.Gas = gasLimit
+	}
+
+	txn, err := c.SignTxn(wrappedTxData)
+	if err != nil {
+		return nil, err
+	}
+
+	txnBytes, err := txn.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	var hash common.Hash
+	if err = c.rpc.Client().Call(&hash, "eth_sendRawTransaction", hexutil.Encode(txnBytes)); err != nil {
+		return nil, err
+	}
+
+	res := &TransactionResult{
+		clt:  c,
+		hash: hash,
+	}
+	return res, nil
 }


### PR DESCRIPTION
## 📝 Summary

This PR adds a new command `suave/devenv/cmd/main.go` to execute the full mev-share example on the development environment.

### Usage
```
$ make devnet-up
$ go run suave/devenv/cmd/main.go
...
```

As a followup PR, I will connect the `mevm` node with the `suave-enabled` node.

---

* [x] I have seen and agree to CONTRIBUTING.md
