### PR TITLE
Disable client wallet

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -117,6 +117,7 @@ func defaultNodeConfig() node.Config {
 	cfg.HTTPModules = append(cfg.HTTPModules, "eth")
 	cfg.WSModules = append(cfg.WSModules, "eth")
 	cfg.IPCPath = "geth.ipc"
+	cfg.InsecureUnlockAllowed = true
 	return cfg
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1828,6 +1828,8 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 // SendTransaction creates a transaction for the given argument, sign it and submit it to the
 // transaction pool.
 func (s *TransactionAPI) SendTransaction(ctx context.Context, args TransactionArgs, confidential *hexutil.Bytes) (common.Hash, error) {
+	return common.Hash{}, fmt.Errorf("method not allowed")
+
 	// Look up the wallet containing the requested signer
 	account := accounts.Account{Address: args.from()}
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -124,9 +124,6 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 		}, {
 			Namespace: "eth",
 			Service:   NewEthereumAccountAPI(apiBackend.AccountManager()),
-		}, {
-			Namespace: "personal",
-			Service:   NewPersonalAccountAPI(apiBackend, nonceLock),
 		},
 	}
 }

--- a/suave/devenv/docker-compose.yml
+++ b/suave/devenv/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - --ws.addr=0.0.0.0
       - --datadir=/data
       - --keystore=/keystore/keystore
-      - --allow-insecure-unlock
       - --unlock=0xB5fEAfbDD752ad52Afb7e1bD2E40432A485bBB7F
       - --password=/keystore/password.txt
     depends_on:


### PR DESCRIPTION
## 📝 Summary

This PR disables the JsonRPC endpoints of the client that involve managing the internal wallets for sending transactions:
- It disables a possible attack vector over Suave deployments ([ref](https://medium.com/coinmonks/securing-your-ethereum-nodes-from-hackers-8b7d5bac8986)).
- It improves the user experience of node administrators by removing the `allow-insecure-unlock` flag.

The PR is intended to be as small as possible to ease upstream changes.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
