### PR TITLE
Add bootnodes list to genesis.json

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1047,6 +1047,12 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		urls = params.RinkebyBootnodes
 	case ctx.Bool(GoerliFlag.Name):
 		urls = params.GoerliBootnodes
+	case ctx.IsSet(CustomChainFlag.Name):
+		jsonGenesis, err := readJSONGenesis(ctx.String(CustomChainFlag.Name))
+		if err != nil {
+			Fatalf("Failed to read bootstrap nodes from genesis %s: %v", CustomChainFlag.Name, err)
+		}
+		urls = jsonGenesis.Bootnodes
 	}
 
 	// don't apply defaults if BootstrapNodes is already set
@@ -2269,6 +2275,8 @@ type jsonGenesis struct {
 			InitialSigners []string `json:"initial_signers"`
 		} `json:"clique,omitempty"`
 	} `json:"config"`
+
+	Bootnodes []string `json:"bootnodes"`
 }
 
 func readJSONGenesis(genesisPath string) (*jsonGenesis, error) {


### PR DESCRIPTION
## 📝 Summary

This PR extends `genesis.json` to add a list of initial bootnodes to connect with.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
