### PR TITLE
Add metrics for counter and time spent on a suave precompile

### DIFF
--- a/core/vm/suave.go
+++ b/core/vm/suave.go
@@ -55,7 +55,7 @@ func (p *SuavePrecompiledContractWrapper) Run(input []byte) ([]byte, error) {
 	}
 
 	if metrics.EnabledExpensive {
-		precompileName := artifacts.ResolvePrecompileAddr(p.addr)
+		precompileName := artifacts.PrecompileAddressToName(p.addr)
 		metrics.GetOrRegisterMeter("suave/runtime/"+precompileName, nil).Mark(1)
 
 		now := time.Now()

--- a/core/vm/suave.go
+++ b/core/vm/suave.go
@@ -2,8 +2,11 @@ package vm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/suave/artifacts"
 	suave "github.com/ethereum/go-ethereum/suave/core"
 )
 
@@ -49,6 +52,16 @@ func (p *SuavePrecompiledContractWrapper) Run(input []byte) ([]byte, error) {
 		impl: &suaveRuntime{
 			backend: p.backend,
 		},
+	}
+
+	if metrics.EnabledExpensive {
+		precompileName := artifacts.ResolvePrecompileAddr(p.addr)
+		metrics.GetOrRegisterMeter("suave/runtime/"+precompileName, nil).Mark(1)
+
+		now := time.Now()
+		defer func() {
+			metrics.GetOrRegisterTimer("suave/runtime/"+precompileName+"/duration", nil).Update(time.Since(now))
+		}()
 	}
 
 	switch p.addr {

--- a/suave/artifacts/addresses.go
+++ b/suave/artifacts/addresses.go
@@ -31,7 +31,7 @@ var SuaveMethods = map[string]common.Address{
 	"submitEthBlockBidToRelay":  submitEthBlockBidToRelayAddr,
 }
 
-func ResolvePrecompileAddr(addr common.Address) string {
+func PrecompileAddressToName(addr common.Address) string {
 	switch addr {
 	case buildEthBlockAddr:
 		return "buildEthBlock"

--- a/suave/artifacts/addresses.go
+++ b/suave/artifacts/addresses.go
@@ -6,14 +6,51 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// List of suave precompile addresses
+var (
+	buildEthBlockAddr             = common.HexToAddress("0x0000000000000000000000000000000042100001")
+	confidentialInputsAddr        = common.HexToAddress("0x0000000000000000000000000000000042010001")
+	confidentialStoreRetrieveAddr = common.HexToAddress("0x0000000000000000000000000000000042020001")
+	confidentialStoreStoreAddr    = common.HexToAddress("0x0000000000000000000000000000000042020000")
+	extractHintAddr               = common.HexToAddress("0x0000000000000000000000000000000042100037")
+	fetchBidsAddr                 = common.HexToAddress("0x0000000000000000000000000000000042030001")
+	newBidAddr                    = common.HexToAddress("0x0000000000000000000000000000000042030000")
+	simulateBundleAddr            = common.HexToAddress("0x0000000000000000000000000000000042100000")
+	submitEthBlockBidToRelayAddr  = common.HexToAddress("0x0000000000000000000000000000000042100002")
+)
+
 var SuaveMethods = map[string]common.Address{
-	"buildEthBlock":             common.HexToAddress("0x0000000000000000000000000000000042100001"),
-	"confidentialInputs":        common.HexToAddress("0x0000000000000000000000000000000042010001"),
-	"confidentialStoreRetrieve": common.HexToAddress("0x0000000000000000000000000000000042020001"),
-	"confidentialStoreStore":    common.HexToAddress("0x0000000000000000000000000000000042020000"),
-	"extractHint":               common.HexToAddress("0x0000000000000000000000000000000042100037"),
-	"fetchBids":                 common.HexToAddress("0x0000000000000000000000000000000042030001"),
-	"newBid":                    common.HexToAddress("0x0000000000000000000000000000000042030000"),
-	"simulateBundle":            common.HexToAddress("0x0000000000000000000000000000000042100000"),
-	"submitEthBlockBidToRelay":  common.HexToAddress("0x0000000000000000000000000000000042100002"),
+	"buildEthBlock":             buildEthBlockAddr,
+	"confidentialInputs":        confidentialInputsAddr,
+	"confidentialStoreRetrieve": confidentialStoreRetrieveAddr,
+	"confidentialStoreStore":    confidentialStoreStoreAddr,
+	"extractHint":               extractHintAddr,
+	"fetchBids":                 fetchBidsAddr,
+	"newBid":                    newBidAddr,
+	"simulateBundle":            simulateBundleAddr,
+	"submitEthBlockBidToRelay":  submitEthBlockBidToRelayAddr,
+}
+
+func ResolvePrecompileAddr(addr common.Address) string {
+	switch addr {
+	case buildEthBlockAddr:
+		return "buildEthBlock"
+	case confidentialInputsAddr:
+		return "confidentialInputs"
+	case confidentialStoreRetrieveAddr:
+		return "confidentialStoreRetrieve"
+	case confidentialStoreStoreAddr:
+		return "confidentialStoreStore"
+	case extractHintAddr:
+		return "extractHint"
+	case fetchBidsAddr:
+		return "fetchBids"
+	case newBidAddr:
+		return "newBid"
+	case simulateBundleAddr:
+		return "simulateBundle"
+	case submitEthBlockBidToRelayAddr:
+		return "submitEthBlockBidToRelay"
+	}
+	return ""
 }

--- a/suave/gen/main.go
+++ b/suave/gen/main.go
@@ -312,7 +312,7 @@ var SuaveMethods = map[string]common.Address{
 {{range .Functions}}"{{.Name}}": {{.Name}}Addr,
 {{end}}}
 
-func ResolvePrecompileAddr(addr common.Address) string {
+func PrecompileAddressToName(addr common.Address) string {
 	switch addr { {{range .Functions}}
 	case {{.Name}}Addr:
 		return "{{.Name}}"{{end}}

--- a/suave/gen/main.go
+++ b/suave/gen/main.go
@@ -303,9 +303,22 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// List of suave precompile addresses
+var ( {{range .Functions}}{{.Name}}Addr = common.HexToAddress("{{.Address}}")
+{{end}}
+)
+
 var SuaveMethods = map[string]common.Address{
-{{range .Functions}}"{{.Name}}": common.HexToAddress("{{.Address}}"),
+{{range .Functions}}"{{.Name}}": {{.Name}}Addr,
 {{end}}}
+
+func ResolvePrecompileAddr(addr common.Address) string {
+	switch addr { {{range .Functions}}
+	case {{.Name}}Addr:
+		return "{{.Name}}"{{end}}
+	}
+	return ""
+}
 `
 
 var suaveLibTemplate = `// SPDX-License-Identifier: UNLICENSED


### PR DESCRIPTION
## 📝 Summary

This PR enables metrics to track how many times a SUAVE precompile gets called and how much time does it take to execute it. 

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
