### PR TITLE
Encode internal wrapped object as JSON child

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -30,24 +30,24 @@ import (
 type txJSON struct {
 	Type hexutil.Uint64 `json:"type"`
 
-	ChainID                   *hexutil.Big    `json:"chainId,omitempty"`
-	Nonce                     *hexutil.Uint64 `json:"nonce"`
-	To                        *common.Address `json:"to"`
-	Gas                       *hexutil.Uint64 `json:"gas"`
-	GasPrice                  *hexutil.Big    `json:"gasPrice"`
-	MaxPriorityFeePerGas      *hexutil.Big    `json:"maxPriorityFeePerGas"`
-	MaxFeePerGas              *hexutil.Big    `json:"maxFeePerGas"`
-	MaxFeePerDataGas          *hexutil.Big    `json:"maxFeePerDataGas,omitempty"`
-	Value                     *hexutil.Big    `json:"value"`
-	Input                     *hexutil.Bytes  `json:"input"`
-	AccessList                *AccessList     `json:"accessList,omitempty"`
-	BlobVersionedHashes       []common.Hash   `json:"blobVersionedHashes,omitempty"`
-	ExecutionNode             *common.Address `json:"executionNode,omitempty"`
-	Wrapped                   *hexutil.Bytes  `json:"wrapped,omitempty"`
-	ConfidentialComputeResult *hexutil.Bytes  `json:"confidentialComputeResult,omitempty"`
-	V                         *hexutil.Big    `json:"v"`
-	R                         *hexutil.Big    `json:"r"`
-	S                         *hexutil.Big    `json:"s"`
+	ChainID                   *hexutil.Big     `json:"chainId,omitempty"`
+	Nonce                     *hexutil.Uint64  `json:"nonce"`
+	To                        *common.Address  `json:"to"`
+	Gas                       *hexutil.Uint64  `json:"gas"`
+	GasPrice                  *hexutil.Big     `json:"gasPrice"`
+	MaxPriorityFeePerGas      *hexutil.Big     `json:"maxPriorityFeePerGas"`
+	MaxFeePerGas              *hexutil.Big     `json:"maxFeePerGas"`
+	MaxFeePerDataGas          *hexutil.Big     `json:"maxFeePerDataGas,omitempty"`
+	Value                     *hexutil.Big     `json:"value"`
+	Input                     *hexutil.Bytes   `json:"input"`
+	AccessList                *AccessList      `json:"accessList,omitempty"`
+	BlobVersionedHashes       []common.Hash    `json:"blobVersionedHashes,omitempty"`
+	ExecutionNode             *common.Address  `json:"executionNode,omitempty"`
+	Wrapped                   *json.RawMessage `json:"wrapped,omitempty"`
+	ConfidentialComputeResult *hexutil.Bytes   `json:"confidentialComputeResult,omitempty"`
+	V                         *hexutil.Big     `json:"v"`
+	R                         *hexutil.Big     `json:"r"`
+	S                         *hexutil.Big     `json:"s"`
 
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
@@ -124,7 +124,7 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 			return nil, err
 		}
 
-		enc.Wrapped = (*hexutil.Bytes)(&wrapped)
+		enc.Wrapped = (*json.RawMessage)(&wrapped)
 		enc.ChainID = (*hexutil.Big)(itx.ChainID)
 
 	case *SuaveTransaction:
@@ -135,7 +135,7 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 			return nil, err
 		}
 
-		enc.Wrapped = (*hexutil.Bytes)(&wrapped)
+		enc.Wrapped = (*json.RawMessage)(&wrapped)
 
 		enc.ChainID = (*hexutil.Big)(itx.ChainID)
 		enc.ConfidentialComputeResult = (*hexutil.Bytes)(&itx.ConfidentialComputeResult)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -19,6 +19,7 @@ package ethapi
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -1376,7 +1377,7 @@ type RPCTransaction struct {
 	Accesses                  *types.AccessList `json:"accessList,omitempty"`
 	ChainID                   *hexutil.Big      `json:"chainId,omitempty"`
 	ExecutionNode             *common.Address   `json:"executionNode,omitempty"`
-	Wrapped                   *hexutil.Bytes    `json:"wrapped,omitempty"`
+	Wrapped                   *json.RawMessage  `json:"wrapped,omitempty"`
 	ConfidentialComputeResult *hexutil.Bytes    `json:"confidentialComputeResult,omitempty"`
 	V                         *hexutil.Big      `json:"v"`
 	R                         *hexutil.Big      `json:"r"`
@@ -1449,7 +1450,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			return nil
 		}
 
-		result.Wrapped = (*hexutil.Bytes)(&wrappedBytes)
+		result.Wrapped = (*json.RawMessage)(&wrappedBytes)
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
 	case types.SuaveTxType:
 		inner, ok := types.CastTxInner[*types.SuaveTransaction](tx)
@@ -1467,7 +1468,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			return nil
 		}
 
-		result.Wrapped = (*hexutil.Bytes)(&wrappedBytes)
+		result.Wrapped = (*json.RawMessage)(&wrappedBytes)
 		result.ConfidentialComputeResult = (*hexutil.Bytes)(&inner.ConfidentialComputeResult)
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
 	}


### PR DESCRIPTION
## 📝 Summary

This PR fixes an issue where the internal `wrapped` transaction of the `ConfidentialRequestTransaction` was encoded as the byte representation of the JSON transaction instead of a child JSON object.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
