### PR TITLE
Move suave-enabled api backends to suave package

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -55,6 +55,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/suave/backends"
 	suave_backends "github.com/ethereum/go-ethereum/suave/backends"
 	suave "github.com/ethereum/go-ethereum/suave/core"
 )
@@ -318,6 +319,12 @@ func makeExtraData(extra []byte) []byte {
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *Ethereum) APIs() []rpc.API {
 	apis := ethapi.GetAPIs(s.APIBackend)
+
+	// Append SUAVE-enabled node backend
+	apis = append(apis, rpc.API{
+		Namespace: "eth", // TODO
+		Service:   backends.NewEthBackendServer(s.APIBackend),
+	})
 
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/accounts/scwallet"
-	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -1326,48 +1325,6 @@ func (s *BlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Block, inc
 		fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, b.Hash()))
 	}
 	return fields, err
-}
-
-func (s *BlockChainAPI) BuildEth2Block(ctx context.Context, buildArgs *types.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error) {
-	if buildArgs == nil {
-		head := s.b.CurrentHeader()
-		buildArgs = &types.BuildBlockArgs{
-			Parent:       head.Hash(),
-			Timestamp:    head.Time + uint64(12),
-			FeeRecipient: common.Address{0x42},
-			GasLimit:     30000000,
-			Random:       head.Root,
-			Withdrawals:  nil,
-		}
-	}
-
-	block, profit, err := s.b.BuildBlockFromTxs(ctx, buildArgs, txs)
-	if err != nil {
-		return nil, err
-	}
-
-	return engine.BlockToExecutableData(block, profit), nil
-}
-
-func (s *BlockChainAPI) BuildEth2BlockFromBundles(ctx context.Context, buildArgs *types.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error) {
-	if buildArgs == nil {
-		head := s.b.CurrentHeader()
-		buildArgs = &types.BuildBlockArgs{
-			Parent:       head.Hash(),
-			Timestamp:    head.Time + uint64(12),
-			FeeRecipient: common.Address{0x42},
-			GasLimit:     30000000,
-			Random:       head.Root,
-			Withdrawals:  nil,
-		}
-	}
-
-	block, profit, err := s.b.BuildBlockFromBundles(ctx, buildArgs, bundles)
-	if err != nil {
-		return nil, err
-	}
-
-	return engine.BlockToExecutableData(block, profit), nil
 }
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
-	suave "github.com/ethereum/go-ethereum/suave/core"
 )
 
 // Backend interface provides the common API services (that are provided by
@@ -98,9 +97,6 @@ type Backend interface {
 	SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
-
-	BuildBlockFromTxs(ctx context.Context, buildArgs *suave.BuildBlockArgs, txs types.Transactions) (*types.Block, *big.Int, error)
-	BuildBlockFromBundles(ctx context.Context, buildArgs *suave.BuildBlockArgs, bundles []types.SBundle) (*types.Block, *big.Int, error)
 }
 
 func GetAPIs(apiBackend Backend) []rpc.API {

--- a/suave/backends/eth_backend_server.go
+++ b/suave/backends/eth_backend_server.go
@@ -1,0 +1,77 @@
+package backends
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	suave "github.com/ethereum/go-ethereum/suave/core"
+)
+
+// EthBackend is the set of functions exposed from the SUAVE-enabled node
+type EthBackend interface {
+	BuildEth2Block(ctx context.Context, buildArgs *types.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error)
+	BuildEth2BlockFromBundles(ctx context.Context, buildArgs *types.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error)
+}
+
+var _ EthBackend = &EthBackendServer{}
+
+// EthBackendServerBackend is the interface implemented by the SUAVE-enabled node
+// to resolve the EthBackend server queries
+type EthBackendServerBackend interface {
+	CurrentHeader() *types.Header
+	BuildBlockFromTxs(ctx context.Context, buildArgs *suave.BuildBlockArgs, txs types.Transactions) (*types.Block, *big.Int, error)
+	BuildBlockFromBundles(ctx context.Context, buildArgs *suave.BuildBlockArgs, bundles []types.SBundle) (*types.Block, *big.Int, error)
+}
+
+type EthBackendServer struct {
+	b EthBackendServerBackend
+}
+
+func NewEthBackendServer(b EthBackendServerBackend) *EthBackendServer {
+	return &EthBackendServer{b}
+}
+
+func (e *EthBackendServer) BuildEth2Block(ctx context.Context, buildArgs *types.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error) {
+	if buildArgs == nil {
+		head := e.b.CurrentHeader()
+		buildArgs = &types.BuildBlockArgs{
+			Parent:       head.Hash(),
+			Timestamp:    head.Time + uint64(12),
+			FeeRecipient: common.Address{0x42},
+			GasLimit:     30000000,
+			Random:       head.Root,
+			Withdrawals:  nil,
+		}
+	}
+
+	block, profit, err := e.b.BuildBlockFromTxs(ctx, buildArgs, txs)
+	if err != nil {
+		return nil, err
+	}
+
+	return engine.BlockToExecutableData(block, profit), nil
+}
+
+func (e *EthBackendServer) BuildEth2BlockFromBundles(ctx context.Context, buildArgs *types.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error) {
+	if buildArgs == nil {
+		head := e.b.CurrentHeader()
+		buildArgs = &types.BuildBlockArgs{
+			Parent:       head.Hash(),
+			Timestamp:    head.Time + uint64(12),
+			FeeRecipient: common.Address{0x42},
+			GasLimit:     30000000,
+			Random:       head.Root,
+			Withdrawals:  nil,
+		}
+	}
+
+	block, profit, err := e.b.BuildBlockFromBundles(ctx, buildArgs, bundles)
+	if err != nil {
+		return nil, err
+	}
+
+	return engine.BlockToExecutableData(block, profit), nil
+}

--- a/suave/backends/eth_backend_server_test.go
+++ b/suave/backends/eth_backend_server_test.go
@@ -1,0 +1,50 @@
+package backends
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	suave "github.com/ethereum/go-ethereum/suave/core"
+)
+
+func TestEthBackend_Compatibility(t *testing.T) {
+	// This test ensures that the client is able to call to the server.
+	// It does not cover the internal logic implemention of the endpoints.
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("eth", NewEthBackendServer(&mockBackend{})))
+
+	clt := &RemoteEthBackend{client: rpc.DialInProc(srv)}
+
+	_, err := clt.BuildEthBlock(context.Background(), &types.BuildBlockArgs{}, nil)
+	require.NoError(t, err)
+
+	_, err = clt.BuildEthBlockFromBundles(context.Background(), &types.BuildBlockArgs{}, nil)
+	require.NoError(t, err)
+}
+
+// mockBackend is a backend for the EthBackendServer that returns mock data
+type mockBackend struct{}
+
+func (n *mockBackend) CurrentHeader() *types.Header {
+	return &types.Header{}
+}
+
+func (n *mockBackend) BuildBlockFromTxs(ctx context.Context, buildArgs *suave.BuildBlockArgs, txs types.Transactions) (*types.Block, *big.Int, error) {
+	block := types.NewBlock(&types.Header{GasUsed: 1000, BaseFee: big.NewInt(1)}, txs, nil, nil, trie.NewStackTrie(nil))
+	return block, big.NewInt(11000), nil
+}
+
+func (n *mockBackend) BuildBlockFromBundles(ctx context.Context, buildArgs *suave.BuildBlockArgs, bundles []types.SBundle) (*types.Block, *big.Int, error) {
+	var txs types.Transactions
+	for _, bundle := range bundles {
+		txs = append(txs, bundle.Txs...)
+	}
+	block := types.NewBlock(&types.Header{GasUsed: 1000, BaseFee: big.NewInt(1)}, txs, nil, nil, trie.NewStackTrie(nil))
+	return block, big.NewInt(11000), nil
+}


### PR DESCRIPTION
## 📝 Summary

This PR introduces two changes:
- It moves the "SUAVE-enabled node" jsonrpc implementations to their own package outside the upstream logic.
- It introduces an end-to-end test to ensure that both client and server are compatible.

The goal of this PR is to isolate the custom SUAVE changes and be able to namespace those endpoints differently in a followup PR.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
