### PR TITLE
Use same naming for both client/server for eth backend

### DIFF
--- a/suave/backends/eth_backend_server.go
+++ b/suave/backends/eth_backend_server.go
@@ -12,8 +12,8 @@ import (
 
 // EthBackend is the set of functions exposed from the SUAVE-enabled node
 type EthBackend interface {
-	BuildEth2Block(ctx context.Context, buildArgs *types.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error)
-	BuildEth2BlockFromBundles(ctx context.Context, buildArgs *types.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error)
+	BuildEthBlock(ctx context.Context, buildArgs *types.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error)
+	BuildEthBlockFromBundles(ctx context.Context, buildArgs *types.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error)
 }
 
 var _ EthBackend = &EthBackendServer{}
@@ -34,7 +34,7 @@ func NewEthBackendServer(b EthBackendServerBackend) *EthBackendServer {
 	return &EthBackendServer{b}
 }
 
-func (e *EthBackendServer) BuildEth2Block(ctx context.Context, buildArgs *types.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error) {
+func (e *EthBackendServer) BuildEthBlock(ctx context.Context, buildArgs *types.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error) {
 	if buildArgs == nil {
 		head := e.b.CurrentHeader()
 		buildArgs = &types.BuildBlockArgs{
@@ -55,7 +55,7 @@ func (e *EthBackendServer) BuildEth2Block(ctx context.Context, buildArgs *types.
 	return engine.BlockToExecutableData(block, profit), nil
 }
 
-func (e *EthBackendServer) BuildEth2BlockFromBundles(ctx context.Context, buildArgs *types.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error) {
+func (e *EthBackendServer) BuildEthBlockFromBundles(ctx context.Context, buildArgs *types.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error) {
 	if buildArgs == nil {
 		head := e.b.CurrentHeader()
 		buildArgs = &types.BuildBlockArgs{

--- a/suave/backends/eth_backends.go
+++ b/suave/backends/eth_backends.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
+var (
+	_ EthBackend = &EthMock{}
+	_ EthBackend = &RemoteEthBackend{}
+)
+
 type EthMock struct{}
 
 func (e *EthMock) BuildEthBlock(ctx context.Context, args *suave.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error) {
@@ -62,14 +67,14 @@ func (e *RemoteEthBackend) call(ctx context.Context, result interface{}, method 
 
 func (e *RemoteEthBackend) BuildEthBlock(ctx context.Context, args *suave.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error) {
 	var result engine.ExecutionPayloadEnvelope
-	err := e.call(ctx, &result, "eth_buildEth2Block", args, txs)
+	err := e.call(ctx, &result, "eth_buildEthBlock", args, txs)
 
 	return &result, err
 }
 
 func (e *RemoteEthBackend) BuildEthBlockFromBundles(ctx context.Context, args *suave.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error) {
 	var result engine.ExecutionPayloadEnvelope
-	err := e.call(ctx, &result, "eth_buildEth2BlockFromBundles", args, bundles)
+	err := e.call(ctx, &result, "eth_buildEthBlockFromBundles", args, bundles)
 
 	return &result, err
 }


### PR DESCRIPTION
## 📝 Summary

This PR changes the names of the `eth backend` API methods so that they match the names in the client side.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
