### PR TITLE
Suavex namespace

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -114,8 +114,8 @@ func defaultNodeConfig() node.Config {
 	cfg := node.DefaultConfig
 	cfg.Name = clientIdentifier
 	cfg.Version = params.VersionWithCommit(git.Commit, git.Date)
-	cfg.HTTPModules = append(cfg.HTTPModules, "eth")
-	cfg.WSModules = append(cfg.WSModules, "eth")
+	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "suavex")
+	cfg.WSModules = append(cfg.WSModules, "eth", "suavex")
 	cfg.IPCPath = "geth.ipc"
 	cfg.InsecureUnlockAllowed = true
 	return cfg

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 clique:1.0 debug:1.0 engine:1.0 eth:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
-	httpAPIs = "eth:1.0 net:1.0 rpc:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 clique:1.0 debug:1.0 engine:1.0 eth:1.0 miner:1.0 net:1.0 rpc:1.0 suavex:1.0 txpool:1.0 web3:1.0"
+	httpAPIs = "eth:1.0 net:1.0 rpc:1.0 suavex:1.0 web3:1.0"
 )
 
 // spawns geth with the given command line args, using a set of flags to minimise

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -322,7 +322,7 @@ func (s *Ethereum) APIs() []rpc.API {
 
 	// Append SUAVE-enabled node backend
 	apis = append(apis, rpc.API{
-		Namespace: "eth", // TODO
+		Namespace: "suavex",
 		Service:   backends.NewEthBackendServer(s.APIBackend),
 	})
 

--- a/suave/backends/eth_backend_server_test.go
+++ b/suave/backends/eth_backend_server_test.go
@@ -17,7 +17,7 @@ func TestEthBackend_Compatibility(t *testing.T) {
 	// This test ensures that the client is able to call to the server.
 	// It does not cover the internal logic implemention of the endpoints.
 	srv := rpc.NewServer()
-	require.NoError(t, srv.RegisterName("eth", NewEthBackendServer(&mockBackend{})))
+	require.NoError(t, srv.RegisterName("suavex", NewEthBackendServer(&mockBackend{})))
 
 	clt := &RemoteEthBackend{client: rpc.DialInProc(srv)}
 

--- a/suave/backends/eth_backends.go
+++ b/suave/backends/eth_backends.go
@@ -62,14 +62,14 @@ func (e *RemoteEthBackend) call(ctx context.Context, result interface{}, method 
 
 func (e *RemoteEthBackend) BuildEthBlock(ctx context.Context, args *suave.BuildBlockArgs, txs types.Transactions) (*engine.ExecutionPayloadEnvelope, error) {
 	var result engine.ExecutionPayloadEnvelope
-	err := e.call(ctx, &result, "eth_buildEth2Block", args, txs)
+	err := e.call(ctx, &result, "suavex_buildEth2Block", args, txs)
 
 	return &result, err
 }
 
 func (e *RemoteEthBackend) BuildEthBlockFromBundles(ctx context.Context, args *suave.BuildBlockArgs, bundles []types.SBundle) (*engine.ExecutionPayloadEnvelope, error) {
 	var result engine.ExecutionPayloadEnvelope
-	err := e.call(ctx, &result, "eth_buildEth2BlockFromBundles", args, bundles)
+	err := e.call(ctx, &result, "suavex_buildEth2BlockFromBundles", args, bundles)
 
 	return &result, err
 }


### PR DESCRIPTION
## 📝 Summary

This PR puts all the execution node API endpoints under a new `suavex` namespace.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
