### PR TITLE
Flat ConfidentialComputeRequest

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -640,7 +640,7 @@ func (pool *TxPool) validateTxBasics(tx *types.Transaction, local bool) error {
 	}
 	// Make sure the transaction is signed properly.
 	if _, err := types.Sender(pool.signer, tx); err != nil {
-		return fmt.Errorf("ErrInvalidSender: %w", err)
+		return ErrInvalidSender
 	}
 	// Drop non-local transactions under our own minimal accepted gas price or tip
 	if !local && tx.GasTipCapIntCmp(pool.gasPrice) < 0 {

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -640,7 +640,7 @@ func (pool *TxPool) validateTxBasics(tx *types.Transaction, local bool) error {
 	}
 	// Make sure the transaction is signed properly.
 	if _, err := types.Sender(pool.signer, tx); err != nil {
-		return ErrInvalidSender
+		return fmt.Errorf("ErrInvalidSender: %w", err)
 	}
 	// Drop non-local transactions under our own minimal accepted gas price or tip
 	if !local && tx.GasTipCapIntCmp(pool.gasPrice) < 0 {

--- a/core/types/confidential.go
+++ b/core/types/confidential.go
@@ -7,64 +7,86 @@ import (
 )
 
 type ConfidentialComputeRequest struct {
-	ExecutionNode common.Address `json:"executionNode" gencodec:"required"`
-	Wrapped       Transaction    `json:"wrapped" gencodec:"required"`
-	ChainID       *big.Int       // Overwrite the wrapped chain id, since different txs handle it differently. Also probably should overwrite V,R,S
+	Nonce    uint64
+	GasPrice *big.Int
+	Gas      uint64
+	To       *common.Address `rlp:"nil"`
+	Value    *big.Int
+	Data     []byte
+
+	ExecutionNode          common.Address
+	ConfidentialInputsHash common.Hash
+
+	ChainID *big.Int
+	V, R, S *big.Int
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *ConfidentialComputeRequest) copy() TxData {
 	cpy := &ConfidentialComputeRequest{
-		ExecutionNode: tx.ExecutionNode,
-		Wrapped:       *NewTx(tx.Wrapped.inner),
-		ChainID:       new(big.Int),
+		Nonce:                  tx.Nonce,
+		To:                     copyAddressPtr(tx.To),
+		Data:                   common.CopyBytes(tx.Data),
+		Gas:                    tx.Gas,
+		ExecutionNode:          tx.ExecutionNode,
+		ConfidentialInputsHash: tx.ConfidentialInputsHash,
+
+		Value:    new(big.Int),
+		GasPrice: new(big.Int),
+
+		ChainID: new(big.Int),
+		V:       new(big.Int),
+		R:       new(big.Int),
+		S:       new(big.Int),
 	}
 
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	if tx.GasPrice != nil {
+		cpy.GasPrice.Set(tx.GasPrice)
+	}
 	if tx.ChainID != nil {
 		cpy.ChainID.Set(tx.ChainID)
+	}
+	if tx.V != nil {
+		cpy.V.Set(tx.V)
+	}
+	if tx.R != nil {
+		cpy.R.Set(tx.R)
+	}
+	if tx.S != nil {
+		cpy.S.Set(tx.S)
 	}
 
 	return cpy
 }
 
-// accessors for innerTx.
-func (tx *ConfidentialComputeRequest) txType() byte {
-	return ConfidentialComputeRequestTxType
-}
-
-func (tx *ConfidentialComputeRequest) data() []byte {
-	return tx.Wrapped.Data()
-}
-
-// Rest is carried over from wrapped tx
-func (tx *ConfidentialComputeRequest) chainID() *big.Int      { return tx.ChainID }
-func (tx *ConfidentialComputeRequest) accessList() AccessList { return tx.Wrapped.inner.accessList() }
-func (tx *ConfidentialComputeRequest) gas() uint64            { return tx.Wrapped.inner.gas() }
-func (tx *ConfidentialComputeRequest) gasFeeCap() *big.Int    { return tx.Wrapped.inner.gasFeeCap() }
-func (tx *ConfidentialComputeRequest) gasTipCap() *big.Int    { return tx.Wrapped.inner.gasTipCap() }
-func (tx *ConfidentialComputeRequest) gasPrice() *big.Int     { return tx.Wrapped.inner.gasFeeCap() }
-func (tx *ConfidentialComputeRequest) value() *big.Int        { return tx.Wrapped.inner.value() }
-func (tx *ConfidentialComputeRequest) nonce() uint64          { return tx.Wrapped.inner.nonce() }
-func (tx *ConfidentialComputeRequest) to() *common.Address    { return tx.Wrapped.inner.to() }
-func (tx *ConfidentialComputeRequest) blobGas() uint64        { return tx.Wrapped.inner.blobGas() }
-func (tx *ConfidentialComputeRequest) blobGasFeeCap() *big.Int {
-	return tx.Wrapped.inner.blobGasFeeCap()
-}
-func (tx *ConfidentialComputeRequest) blobHashes() []common.Hash {
-	return tx.Wrapped.inner.blobHashes()
-}
+func (tx *ConfidentialComputeRequest) txType() byte              { return ConfidentialComputeRequestTxType }
+func (tx *ConfidentialComputeRequest) chainID() *big.Int         { return tx.ChainID }
+func (tx *ConfidentialComputeRequest) accessList() AccessList    { return nil }
+func (tx *ConfidentialComputeRequest) data() []byte              { return tx.Data }
+func (tx *ConfidentialComputeRequest) gas() uint64               { return tx.Gas }
+func (tx *ConfidentialComputeRequest) gasPrice() *big.Int        { return tx.GasPrice }
+func (tx *ConfidentialComputeRequest) gasTipCap() *big.Int       { return tx.GasPrice }
+func (tx *ConfidentialComputeRequest) gasFeeCap() *big.Int       { return tx.GasPrice }
+func (tx *ConfidentialComputeRequest) value() *big.Int           { return tx.Value }
+func (tx *ConfidentialComputeRequest) nonce() uint64             { return tx.Nonce }
+func (tx *ConfidentialComputeRequest) to() *common.Address       { return tx.To }
+func (tx *ConfidentialComputeRequest) blobGas() uint64           { return 0 }
+func (tx *ConfidentialComputeRequest) blobGasFeeCap() *big.Int   { return nil }
+func (tx *ConfidentialComputeRequest) blobHashes() []common.Hash { return nil }
 
 func (tx *ConfidentialComputeRequest) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
-	return tx.Wrapped.inner.effectiveGasPrice(dst, baseFee)
+	return dst.Set(tx.GasPrice)
 }
 
 func (tx *ConfidentialComputeRequest) rawSignatureValues() (v, r, s *big.Int) {
-	return tx.Wrapped.inner.rawSignatureValues()
+	return tx.V, tx.R, tx.S
 }
 
 func (tx *ConfidentialComputeRequest) setSignatureValues(chainID, v, r, s *big.Int) {
-	tx.ChainID = new(big.Int).Set(chainID)
-	tx.Wrapped.inner.setSignatureValues(chainID, v, r, s)
+	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
 }
 
 type SuaveTransaction struct {

--- a/core/types/confidential.go
+++ b/core/types/confidential.go
@@ -14,8 +14,7 @@ type ConfidentialComputeRequest struct {
 	Value    *big.Int
 	Data     []byte
 
-	ExecutionNode          common.Address
-	ConfidentialInputsHash common.Hash
+	ExecutionNode common.Address
 
 	ChainID *big.Int
 	V, R, S *big.Int
@@ -24,12 +23,11 @@ type ConfidentialComputeRequest struct {
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *ConfidentialComputeRequest) copy() TxData {
 	cpy := &ConfidentialComputeRequest{
-		Nonce:                  tx.Nonce,
-		To:                     copyAddressPtr(tx.To),
-		Data:                   common.CopyBytes(tx.Data),
-		Gas:                    tx.Gas,
-		ExecutionNode:          tx.ExecutionNode,
-		ConfidentialInputsHash: tx.ConfidentialInputsHash,
+		Nonce:         tx.Nonce,
+		To:            copyAddressPtr(tx.To),
+		Data:          common.CopyBytes(tx.Data),
+		Gas:           tx.Gas,
+		ExecutionNode: tx.ExecutionNode,
 
 		Value:    new(big.Int),
 		GasPrice: new(big.Int),

--- a/core/types/confidential_test.go
+++ b/core/types/confidential_test.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCCR(t *testing.T) {
+	testKey, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	require.NoError(t, err)
+
+	signer := NewSuaveSigner(new(big.Int))
+	unsignedTx := NewTx(&ConfidentialComputeRequest{})
+	signedTx, err := SignTx(unsignedTx, signer, testKey)
+	require.NoError(t, err)
+
+	recoveredSender, err := signer.Sender(signedTx)
+	require.NoError(t, err)
+
+	require.Equal(t, crypto.PubkeyToAddress(testKey.PublicKey), recoveredSender)
+
+	marshalledTxBytes, err := signedTx.MarshalBinary()
+	require.NoError(t, err)
+
+	unmarshalledTx := new(Transaction)
+	require.NoError(t, unmarshalledTx.UnmarshalBinary(marshalledTxBytes))
+
+	recoveredUnmarshalledSender, err := signer.Sender(unmarshalledTx)
+	require.NoError(t, err)
+
+	require.Equal(t, crypto.PubkeyToAddress(testKey.PublicKey), recoveredUnmarshalledSender)
+}
+
+func TestSuaveTx(t *testing.T) {
+	testKey, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	require.NoError(t, err)
+
+	signer := NewSuaveSigner(new(big.Int))
+
+	signedCCR, err := SignTx(NewTx(&ConfidentialComputeRequest{
+		ExecutionNode: crypto.PubkeyToAddress(testKey.PublicKey),
+	}), signer, testKey)
+	require.NoError(t, err)
+
+	unsignedTx := NewTx(&SuaveTransaction{
+		ExecutionNode:              crypto.PubkeyToAddress(testKey.PublicKey),
+		ConfidentialComputeRequest: *signedCCR,
+	})
+	signedTx, err := SignTx(unsignedTx, signer, testKey)
+	require.NoError(t, err)
+
+	recoveredSender, err := signer.Sender(signedTx)
+	require.NoError(t, err)
+
+	require.Equal(t, crypto.PubkeyToAddress(testKey.PublicKey), recoveredSender)
+
+	marshalledTxBytes, err := signedTx.MarshalBinary()
+	require.NoError(t, err)
+
+	unmarshalledTx := new(Transaction)
+	require.NoError(t, unmarshalledTx.UnmarshalBinary(marshalledTxBytes))
+
+	recoveredUnmarshalledSender, err := signer.Sender(unmarshalledTx)
+	require.NoError(t, err)
+
+	require.Equal(t, crypto.PubkeyToAddress(testKey.PublicKey), recoveredUnmarshalledSender)
+}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -43,6 +43,7 @@ type txJSON struct {
 	AccessList                *AccessList      `json:"accessList,omitempty"`
 	BlobVersionedHashes       []common.Hash    `json:"blobVersionedHashes,omitempty"`
 	ExecutionNode             *common.Address  `json:"executionNode,omitempty"`
+	ConfidentialInputsHash    common.Hash      `json:"confidentialInputsHash,omitempty"`
 	Wrapped                   *json.RawMessage `json:"wrapped,omitempty"`
 	ConfidentialComputeResult *hexutil.Bytes   `json:"confidentialComputeResult,omitempty"`
 	V                         *hexutil.Big     `json:"v"`
@@ -118,14 +119,17 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 
 	case *ConfidentialComputeRequest:
 		enc.ExecutionNode = &itx.ExecutionNode
-
-		wrapped, err := itx.Wrapped.MarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-
-		enc.Wrapped = (*json.RawMessage)(&wrapped)
+		enc.ConfidentialInputsHash = itx.ConfidentialInputsHash
+		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
+		enc.To = tx.To()
+		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
+		enc.GasPrice = (*hexutil.Big)(itx.GasPrice)
+		enc.Value = (*hexutil.Big)(itx.Value)
+		enc.Input = (*hexutil.Bytes)(&itx.Data)
 		enc.ChainID = (*hexutil.Big)(itx.ChainID)
+		enc.V = (*hexutil.Big)(itx.V)
+		enc.R = (*hexutil.Big)(itx.R)
+		enc.S = (*hexutil.Big)(itx.S)
 
 	case *SuaveTransaction:
 		enc.ExecutionNode = &itx.ExecutionNode
@@ -384,25 +388,55 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.ExecutionNode == nil {
 			return errors.New("missing required field 'executionNode' in transaction")
 		}
-
 		itx.ExecutionNode = *dec.ExecutionNode
 
-		if dec.Wrapped == nil {
-			return errors.New("missing required field 'wrapped' in transaction")
+		itx.ConfidentialInputsHash = dec.ConfidentialInputsHash
+
+		if dec.Nonce == nil {
+			return errors.New("missing required field 'nonce' in transaction")
 		}
-
-		var wrappedTx Transaction
-		err := wrappedTx.UnmarshalJSON(([]byte)(*dec.Wrapped))
-		if err != nil {
-			return err
+		itx.Nonce = uint64(*dec.Nonce)
+		if dec.To != nil {
+			itx.To = dec.To
 		}
-
-		itx.Wrapped = wrappedTx
-
+		if dec.Gas == nil {
+			return errors.New("missing required field 'gas' in transaction")
+		}
+		itx.Gas = uint64(*dec.Gas)
+		if dec.GasPrice == nil {
+			return errors.New("missing required field 'gasPrice' in transaction")
+		}
+		itx.GasPrice = (*big.Int)(dec.GasPrice)
+		if dec.Value == nil {
+			return errors.New("missing required field 'value' in transaction")
+		}
+		itx.Value = (*big.Int)(dec.Value)
+		if dec.Input == nil {
+			return errors.New("missing required field 'input' in transaction")
+		}
+		itx.Data = *dec.Input
 		if dec.ChainID == nil {
 			return errors.New("missing required field 'chainId' in transaction")
 		}
 		itx.ChainID = (*big.Int)(dec.ChainID)
+		if dec.V == nil {
+			return errors.New("missing required field 'r' in transaction")
+		}
+		itx.V = (*big.Int)(dec.V)
+		if dec.R == nil {
+			return errors.New("missing required field 'r' in transaction")
+		}
+		itx.R = (*big.Int)(dec.R)
+		if dec.S == nil {
+			return errors.New("missing required field 's' in transaction")
+		}
+		itx.S = (*big.Int)(dec.S)
+		withSignature := itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0
+		if withSignature {
+			if err := sanityCheckSignature(itx.V, itx.R, itx.S, false); err != nil {
+				return err
+			}
+		}
 
 	case SuaveTxType:
 		var itx SuaveTransaction

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -119,7 +119,6 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 
 	case *ConfidentialComputeRequest:
 		enc.ExecutionNode = &itx.ExecutionNode
-		enc.ConfidentialInputsHash = itx.ConfidentialInputsHash
 		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
 		enc.To = tx.To()
 		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
@@ -389,8 +388,6 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'executionNode' in transaction")
 		}
 		itx.ExecutionNode = *dec.ExecutionNode
-
-		itx.ConfidentialInputsHash = dec.ConfidentialInputsHash
 
 		if dec.Nonce == nil {
 			return errors.New("missing required field 'nonce' in transaction")

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -337,7 +337,6 @@ func (s suaveSigner) Hash(tx *Transaction) common.Hash {
 			tx.Type(),
 			[]interface{}{
 				txdata.ExecutionNode,
-				txdata.ConfidentialInputsHash,
 				tx.Nonce(),
 				tx.GasPrice(),
 				tx.Gas(),

--- a/core/vm/contracts_suave_test.go
+++ b/core/vm/contracts_suave_test.go
@@ -81,7 +81,6 @@ func TestSuavePrecompileStub(t *testing.T) {
 
 	reqTx := types.NewTx(&types.ConfidentialComputeRequest{
 		ExecutionNode: common.Address{},
-		Wrapped:       *types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), nil),
 	})
 
 	suaveContext := SuaveContext{
@@ -149,7 +148,6 @@ func newTestBackend(t *testing.T) *suaveRuntime {
 
 	reqTx := types.NewTx(&types.ConfidentialComputeRequest{
 		ExecutionNode: common.Address{},
-		Wrapped:       *types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), nil),
 	})
 
 	b := &suaveRuntime{

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2011,10 +2011,6 @@ func runMEVM(ctx context.Context, b Backend, state *state.StateDB, header *types
 		return nil, nil, nil, err
 	}
 
-	log.Info("xx", "chainid", tx.ChainId())
-	acc1, err := types.NewSuaveSigner(tx.ChainId()).Sender(tx)
-	log.Info("xx", "acc1", acc1, "err", err)
-
 	// will copy the inner tx again!
 	return signed, result, storeFinalize, nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1439,7 +1439,6 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		}
 
 		result.ExecutionNode = &inner.ExecutionNode
-		result.ConfidentialInputsHash = &inner.ConfidentialInputsHash
 
 		// if a legacy transaction has an EIP-155 chain id, include it explicitly
 		if id := tx.ChainId(); id.Sign() != 0 {

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -35,18 +35,19 @@ import (
 // TransactionArgs represents the arguments to construct a new transaction
 // or a message call.
 type TransactionArgs struct {
-	From                 *common.Address `json:"from"`
-	To                   *common.Address `json:"to"`
-	Gas                  *hexutil.Uint64 `json:"gas"`
-	GasPrice             *hexutil.Big    `json:"gasPrice"`
-	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
-	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
-	Value                *hexutil.Big    `json:"value"`
-	ExecutionNode        *common.Address `json:"executionNode"`
-	IsConfidential       bool            `json:"IsConfidential"`
-	ConfidentialInputs   *hexutil.Bytes  `json:"confidentialInputs"` // TODO: testme
-	ConfidentialResult   *hexutil.Bytes  `json:"ConfidentialResult"` // TODO: testme
-	Nonce                *hexutil.Uint64 `json:"nonce"`
+	From                   *common.Address `json:"from"`
+	To                     *common.Address `json:"to"`
+	Gas                    *hexutil.Uint64 `json:"gas"`
+	GasPrice               *hexutil.Big    `json:"gasPrice"`
+	MaxFeePerGas           *hexutil.Big    `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas   *hexutil.Big    `json:"maxPriorityFeePerGas"`
+	Value                  *hexutil.Big    `json:"value"`
+	IsConfidential         bool            `json:"IsConfidential"`
+	ExecutionNode          *common.Address `json:"executionNode"`
+	ConfidentialInputsHash *common.Hash    `json:"confidentialInputsHash"` // TODO: testme
+	ConfidentialInputs     *hexutil.Bytes  `json:"confidentialInputs"`     // TODO: testme
+	ConfidentialResult     *hexutil.Bytes  `json:"ConfidentialResult"`     // TODO: testme
+	Nonce                  *hexutil.Uint64 `json:"nonce"`
 
 	// We accept "data" and "input" for backwards-compatibility reasons.
 	// "input" is the newer name and should be preferred by clients.
@@ -286,6 +287,11 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 // toTransaction converts the arguments to a transaction.
 // This assumes that setDefaults has been called.
 func (args *TransactionArgs) toTransaction() *types.Transaction {
+	var executionNode common.Address
+	if args.IsConfidential && args.ExecutionNode != nil {
+		executionNode = *args.ExecutionNode
+	}
+
 	var data types.TxData
 	switch {
 	case args.MaxFeePerGas != nil:
@@ -325,20 +331,27 @@ func (args *TransactionArgs) toTransaction() *types.Transaction {
 		}
 
 		data = &types.SuaveTransaction{
-			ExecutionNode:              *args.ExecutionNode,
+			ExecutionNode:              executionNode,
 			ChainID:                    (*big.Int)(args.ChainID),
 			ConfidentialComputeRequest: *requestArgs.toTransaction(),
 			ConfidentialComputeResult:  confResult,
 		}
 	case args.ExecutionNode != nil:
-		wrappedArgs := *args
-		wrappedArgs.ExecutionNode = nil
-
-		data = &types.ConfidentialComputeRequest{
-			ExecutionNode: *args.ExecutionNode,
-			Wrapped:       *wrappedArgs.toTransaction(),
-			ChainID:       (*big.Int)(args.ChainID),
+		ccrData := &types.ConfidentialComputeRequest{
+			ExecutionNode: executionNode,
+			To:            args.To,
+			Nonce:         uint64(*args.Nonce),
+			Gas:           uint64(*args.Gas),
+			GasPrice:      (*big.Int)(args.GasPrice),
+			Value:         (*big.Int)(args.Value),
+			Data:          args.data(),
 		}
+
+		if args.ConfidentialInputsHash != nil {
+			ccrData.ConfidentialInputsHash = *args.ConfidentialInputsHash
+		}
+
+		data = ccrData
 	default:
 		data = &types.LegacyTx{
 			To:       args.To,
@@ -348,14 +361,6 @@ func (args *TransactionArgs) toTransaction() *types.Transaction {
 			Value:    (*big.Int)(args.Value),
 			Data:     args.data(),
 		}
-	}
-
-	if args.IsConfidential {
-		var executionNode common.Address
-		if args.ExecutionNode != nil {
-			executionNode = *args.ExecutionNode
-		}
-		data = &types.ConfidentialComputeRequest{ExecutionNode: executionNode, Wrapped: *types.NewTx(data), ChainID: (*big.Int)(args.ChainID)}
 	}
 
 	return types.NewTx(data)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -347,10 +347,6 @@ func (args *TransactionArgs) toTransaction() *types.Transaction {
 			Data:          args.data(),
 		}
 
-		if args.ConfidentialInputsHash != nil {
-			ccrData.ConfidentialInputsHash = *args.ConfidentialInputsHash
-		}
-
 		data = ccrData
 	default:
 		data = &types.LegacyTx{

--- a/suave/backends/redis_backends_test.go
+++ b/suave/backends/redis_backends_test.go
@@ -85,7 +85,6 @@ func TestEngineOnRedis(t *testing.T) {
 	testKey, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	dummyCreationTx, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
 		ExecutionNode: common.Address{},
-		Wrapped:       *types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), nil),
 	}), types.NewSuaveSigner(new(big.Int)), testKey)
 	require.NoError(t, err)
 

--- a/suave/backends/redis_transport.go
+++ b/suave/backends/redis_transport.go
@@ -95,13 +95,13 @@ func (r *RedisPubSubTransport) Subscribe() (<-chan suave.DAMessage, context.Canc
 			var msg suave.DAMessage
 			msgBytes := common.Hex2Bytes(rmsg.Payload)
 			if err != nil {
-				log.Info("Redis pubsub: could not decode message from subscription", "err", err, "msg", rmsg.Payload)
+				log.Trace("Redis pubsub: could not decode message from subscription", "err", err, "msg", rmsg.Payload)
 				continue
 			}
 
 			err = json.Unmarshal(msgBytes, &msg)
 			if err != nil {
-				log.Info("Redis pubsub: could not parse message from subscription", "err", err, "msg", rmsg.Payload)
+				log.Trace("Redis pubsub: could not parse message from subscription", "err", err, "msg", rmsg.Payload)
 				continue
 			}
 
@@ -110,7 +110,7 @@ func (r *RedisPubSubTransport) Subscribe() (<-chan suave.DAMessage, context.Canc
 			m := make(map[string]interface{})
 			err = json.Unmarshal(msgBytes, &m)
 			if err != nil {
-				log.Info("Redis pubsub: could not parse message from subscription", "err", err, "msg", rmsg.Payload)
+				log.Trace("Redis pubsub: could not parse message from subscription", "err", err, "msg", rmsg.Payload)
 				continue
 			}
 
@@ -120,7 +120,7 @@ func (r *RedisPubSubTransport) Subscribe() (<-chan suave.DAMessage, context.Canc
 				msg.Value = common.FromHex(m["value"].(string))
 			*/
 
-			log.Info("Redis pubsub: new message", "msg", msg)
+			log.Debug("Redis pubsub: new message", "msg", msg)
 			select {
 			case <-ctx.Done():
 				log.Info("Redis pubsub: closing subscription")

--- a/suave/backends/transactional_store_test.go
+++ b/suave/backends/transactional_store_test.go
@@ -17,7 +17,6 @@ func TestTransactionalStore(t *testing.T) {
 	testKey, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	dummyCreationTx, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
 		ExecutionNode: common.Address{0x42},
-		Wrapped:       *types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), nil),
 	}), types.NewSuaveSigner(new(big.Int)), testKey)
 	require.NoError(t, err)
 

--- a/suave/cmd/suavecli/sendBuildShareBlock.go
+++ b/suave/cmd/suavecli/sendBuildShareBlock.go
@@ -174,20 +174,17 @@ func sendBuildShareBlockTx(
 	calldata, err := ethBlockBidSenderAbi.Pack("buildMevShare", payloadArgsTuple, goerliBlockNum)
 	RequireNoErrorf(err, "could not pack buildMevShare args: %v", err)
 
-	wrappedTxData := &types.DynamicFeeTx{
-		Nonce:     suaveAccNonce,
-		To:        &blockSenderAddr,
-		Value:     nil,
-		Gas:       1000000,
-		GasTipCap: big.NewInt(10),
-		GasFeeCap: big.NewInt(33000000000),
-		Data:      calldata,
+	wrappedTxData := &types.ConfidentialComputeRequest{
+		ExecutionNode: executionNodeAddress,
+		Nonce:         suaveAccNonce,
+		To:            &blockSenderAddr,
+		Value:         nil,
+		Gas:           1000000,
+		GasPrice:      big.NewInt(33000000000),
+		Data:          calldata,
 	}
 
-	confidentialRequestTx, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
-		ExecutionNode: executionNodeAddress,
-		Wrapped:       *types.NewTx(wrappedTxData),
-	}), suaveSigner, privKey)
+	confidentialRequestTx, err := types.SignTx(types.NewTx(wrappedTxData), suaveSigner, privKey)
 	RequireNoErrorf(err, "could not sign confidentialRequestTx: %v", err)
 
 	confidentialRequestTxBytes, err := confidentialRequestTx.MarshalBinary()

--- a/suave/cmd/suavecli/sendMevShareBundle.go
+++ b/suave/cmd/suavecli/sendMevShareBundle.go
@@ -174,20 +174,17 @@ func prepareEthBundle(
 }
 
 func prepareMevShareBidTx(suaveSigner types.Signer, privKey *ecdsa.PrivateKey, executionNodeAddr common.Address, suaveAccNonce uint64, calldata []byte, mevShareAddr common.Address) (*types.Transaction, hexutil.Bytes, error) {
-	wrappedTxData := &types.DynamicFeeTx{
-		Nonce:     suaveAccNonce,
-		To:        &mevShareAddr,
-		Value:     nil,
-		Gas:       10000000,
-		GasTipCap: big.NewInt(10),
-		GasFeeCap: big.NewInt(33000000000),
-		Data:      calldata,
+	wrappedTxData := &types.ConfidentialComputeRequest{
+		ExecutionNode: executionNodeAddr,
+		Nonce:         suaveAccNonce,
+		To:            &mevShareAddr,
+		Value:         nil,
+		Gas:           10000000,
+		GasPrice:      big.NewInt(33000000000),
+		Data:          calldata,
 	}
 
-	confidentialRequestTx, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
-		ExecutionNode: executionNodeAddr,
-		Wrapped:       *types.NewTx(wrappedTxData),
-	}), suaveSigner, privKey)
+	confidentialRequestTx, err := types.SignTx(types.NewTx(wrappedTxData), suaveSigner, privKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/suave/cmd/suavecli/sendMevShareMatch.go
+++ b/suave/cmd/suavecli/sendMevShareMatch.go
@@ -173,20 +173,17 @@ func prepareEthBackrunBundle(
 }
 
 func prepareMevBackrunBidTx(suaveSigner types.Signer, privKey *ecdsa.PrivateKey, executionNodeAddr common.Address, suaveAccNonce uint64, calldata []byte, mevShareAddr common.Address) (*types.Transaction, hexutil.Bytes, error) {
-	wrappedTxData := &types.DynamicFeeTx{
-		Nonce:     suaveAccNonce,
-		To:        &mevShareAddr,
-		Value:     nil,
-		Gas:       10000000,
-		GasTipCap: big.NewInt(10),
-		GasFeeCap: big.NewInt(33000000000),
-		Data:      calldata,
+	wrappedTxData := &types.ConfidentialComputeRequest{
+		ExecutionNode: executionNodeAddr,
+		Nonce:         suaveAccNonce,
+		To:            &mevShareAddr,
+		Value:         nil,
+		Gas:           10000000,
+		GasPrice:      big.NewInt(33000000000),
+		Data:          calldata,
 	}
 
-	confidentialRequestTx, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
-		ExecutionNode: executionNodeAddr,
-		Wrapped:       *types.NewTx(wrappedTxData),
-	}), suaveSigner, privKey)
+	confidentialRequestTx, err := types.SignTx(types.NewTx(wrappedTxData), suaveSigner, privKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/suave/core/engine_test.go
+++ b/suave/core/engine_test.go
@@ -69,7 +69,6 @@ func TestOwnMessageDropping(t *testing.T) {
 	// testKeyAddress := crypto.PubkeyToAddress(testKey.PublicKey)
 	dummyCreationTx, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
 		ExecutionNode: common.Address{0x42},
-		Wrapped:       *types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), nil),
 	}), types.NewSuaveSigner(new(big.Int)), testKey)
 	require.NoError(t, err)
 

--- a/suave/e2e/workflow_test.go
+++ b/suave/e2e/workflow_test.go
@@ -70,18 +70,14 @@ func TestIsConfidential(t *testing.T) {
 
 	{
 		// Verify sending computation requests and onchain transactions to isConfidentialAddress
-		wrappedTxData := &types.LegacyTx{
-			Nonce:    0,
-			To:       &isConfidentialAddress,
-			Value:    nil,
-			Gas:      1000000,
-			GasPrice: big.NewInt(10),
-			Data:     []byte{},
-		}
-
 		confidentialRequestTx, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
 			ExecutionNode: fr.ExecutionNode(),
-			Wrapped:       *types.NewTx(wrappedTxData),
+			Nonce:         0,
+			To:            &isConfidentialAddress,
+			Value:         nil,
+			Gas:           1000000,
+			GasPrice:      big.NewInt(10),
+			Data:          []byte{},
 		}), signer, testKey)
 		require.NoError(t, err)
 
@@ -136,7 +132,7 @@ func TestMempool(t *testing.T) {
 
 	{
 		targetBlock := uint64(16103213)
-		creationTx := types.NewTx(&types.ConfidentialComputeRequest{ExecutionNode: fr.ExecutionNode(), Wrapped: *types.NewTx(&types.LegacyTx{})})
+		creationTx := types.NewTx(&types.ConfidentialComputeRequest{ExecutionNode: fr.ExecutionNode()})
 
 		bid1, err := fr.ConfidentialEngine().InitializeBid(types.Bid{
 			Salt:                suave.RandomBidId(),
@@ -191,18 +187,14 @@ func TestMempool(t *testing.T) {
 		require.Equal(t, bid2.Version, bids[1].Version)
 
 		// Verify via transaction
-		wrappedTxData := &types.LegacyTx{
-			Nonce:    0,
-			To:       &fetchBidsAddress,
-			Value:    nil,
-			Gas:      1000000,
-			GasPrice: big.NewInt(10),
-			Data:     calldata,
-		}
-
 		confidentialRequestTx, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
 			ExecutionNode: fr.ExecutionNode(),
-			Wrapped:       *types.NewTx(wrappedTxData),
+			Nonce:         0,
+			To:            &fetchBidsAddress,
+			Value:         nil,
+			Gas:           1000000,
+			GasPrice:      big.NewInt(10),
+			Data:          calldata,
 		}), signer, testKey)
 		require.NoError(t, err)
 
@@ -509,7 +501,6 @@ func TestBlockBuildingPrecompiles(t *testing.T) {
 
 		dummyCreationTx, err := types.SignNewTx(testKey, signer, &types.ConfidentialComputeRequest{
 			ExecutionNode: fr.ExecutionNode(),
-			Wrapped:       *types.NewTx(&types.LegacyTx{}),
 		})
 		require.NoError(t, err)
 

--- a/suave/sdk/sdk.go
+++ b/suave/sdk/sdk.go
@@ -64,18 +64,14 @@ func (c *Contract) SendTransaction(method string, args []interface{}, confidenti
 		return nil, err
 	}
 
-	wrappedTxData := &types.LegacyTx{
-		Nonce:    nonce,
-		To:       &c.addr,
-		Value:    nil,
-		GasPrice: gasPrice,
-		Gas:      1000000,
-		Data:     calldata,
-	}
-
 	computeRequest, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{
 		ExecutionNode: c.client.execNode,
-		Wrapped:       *types.NewTx(wrappedTxData),
+		Nonce:         nonce,
+		To:            &c.addr,
+		Value:         nil,
+		GasPrice:      gasPrice,
+		Gas:           1000000,
+		Data:          calldata,
 	}), signer, c.client.key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## 📝 Summary

Flattens the CCR. Signatures work the same way as SuaveTransaction. Uses GasPrice (legacy-style) for controlling gas.

## 📚 References

https://github.com/flashbots/suave-specs/pull/3

---

* [*] I have seen and agree to CONTRIBUTING.md
