### PR TITLE
Add suave computor development mode

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -191,6 +192,7 @@ var (
 		utils.SuaveEthRemoteBackendEndpointFlag,
 		utils.SuaveConfidentialTransportRedisEndpointFlag,
 		utils.SuaveConfidentialStoreRedisEndpointFlag,
+		utils.SuaveDevModeFlag,
 	}
 )
 
@@ -333,6 +335,10 @@ func geth(ctx *cli.Context) error {
 		return fmt.Errorf("invalid command: %q", args[0])
 	}
 
+	if err := prepareSuaveDev(ctx); err != nil {
+		return fmt.Errorf("failed to setup suave development mode: %v", err)
+	}
+
 	prepare(ctx)
 	stack, backend := makeFullNode(ctx)
 	defer stack.Close()
@@ -470,3 +476,62 @@ func unlockAccounts(ctx *cli.Context, stack *node.Node) {
 		unlockAccount(ks, account, i, passwords)
 	}
 }
+
+func prepareSuaveDev(ctx *cli.Context) error {
+	// if suave dev mode is enabled, we need to set some defaults
+	if !ctx.Bool(utils.SuaveDevModeFlag.Name) {
+		return nil
+	}
+
+	suaveDataTmpPath := "/tmp/suave-dev"
+	keystorePath := suaveDataTmpPath + "/keystore"
+	passwordPath := suaveDataTmpPath + "/password.txt"
+
+	// create a data directory under /tmp/suave-dev (if it does not exists) to store
+	// the keystore and the password (empty file) to unlock the execution node account.
+	if _, err := os.Stat(suaveDataTmpPath); err != nil {
+		if err := os.MkdirAll(suaveDataTmpPath, 0755); err != nil {
+			return err
+		}
+
+		// create the keystore
+		if err := os.MkdirAll(keystorePath, 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(keystorePath, "key.json"), []byte(suaveKeystore), 0755); err != nil {
+			return err
+		}
+
+		// create the password
+		if err := os.WriteFile(passwordPath, []byte(""), 0755); err != nil {
+			return err
+		}
+	}
+
+	// set the flags
+	flags := map[string]string{
+		utils.DeveloperFlag.Name:         "true",
+		utils.DeveloperGasLimitFlag.Name: "30000000",
+		utils.HTTPEnabledFlag.Name:       "true",
+		utils.HTTPPortFlag.Name:          "8545",
+		utils.HTTPVirtualHostsFlag.Name:  "*",
+		utils.HTTPCORSDomainFlag.Name:    "*",
+		utils.WSEnabledFlag.Name:         "true",
+		utils.WSAllowedOriginsFlag.Name:  "*",
+		utils.WSListenAddrFlag.Name:      "0.0.0.0",
+		utils.DataDirFlag.Name:           suaveDataTmpPath,
+		utils.KeyStoreDirFlag.Name:       keystorePath,
+		utils.UnlockedAccountFlag.Name:   "0xB5fEAfbDD752ad52Afb7e1bD2E40432A485bBB7F",
+		utils.PasswordFileFlag.Name:      passwordPath,
+	}
+
+	for k, v := range flags {
+		if err := ctx.Set(k, v); err != nil {
+			panic(fmt.Sprintf("bad flag: %v", k))
+		}
+	}
+
+	return nil
+}
+
+var suaveKeystore = `{"address":"b5feafbdd752ad52afb7e1bd2e40432a485bbb7f","crypto":{"cipher":"aes-128-ctr","ciphertext":"8075ff2ed17c6cf6cd162b4bdd2926034e2067f03055990d57510e5d807ef06e","cipherparams":{"iv":"8c31b77d9518a68fda4aa6c90d62562d"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"6e55b1eea32430c4dc0b87cfc31168d552249b8ba946314e3c41dbeaeed3d125"},"mac":"5e411244fd732deb4464d247cfeb9beadc8a37558f12720c4d2ee8691436c50c"},"id":"51d12702-2276-44a9-972e-2011c56edf4e","version":3}`

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -537,6 +537,12 @@ var (
 		Category: flags.SuaveCategory,
 	}
 
+	SuaveDevModeFlag = &cli.BoolFlag{
+		Name:     "suave.dev",
+		Usage:    "Dev mode for suave",
+		Category: flags.SuaveCategory,
+	}
+
 	// Account settings
 	UnlockedAccountFlag = &cli.StringFlag{
 		Name:     "unlock",


### PR DESCRIPTION
## 📝 Summary

This PR introduces a new flag `--suave.dev` (name TBD) that deploys a `Suave` computor in development mode, this is, with the unlocked account of the executor. It is a wrapper around the set of flags used in the docker-compose file that powers `make devnet-up`.

With the new flag, you can run:
```
$ suave --suave.dev
```
and have a computor up and running.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
