### PR TITLE
Appends local addresses to allowed stores on bid initialization

### DIFF
--- a/suave/cstore/engine.go
+++ b/suave/cstore/engine.go
@@ -156,6 +156,9 @@ func (e *ConfidentialStoreEngine) ProcessMessages() {
 }
 
 func (e *ConfidentialStoreEngine) InitializeBid(bid types.Bid, creationTx *types.Transaction) (suave.Bid, error) {
+	// Share with all stores this node trusts
+	bid.AllowedStores = append(bid.AllowedStores, e.daSigner.LocalAddresses()...)
+
 	expectedId, err := calculateBidId(bid)
 	if err != nil {
 		return suave.Bid{}, fmt.Errorf("confidential engine: could not initialize new bid: %w", err)


### PR DESCRIPTION
## 📝 Summary

* Appends local addresses to allowed stores on bid initialization
* This means users don't need to deal with allowed stores if multiple nodes serve a single RPC endpoint

## 📚 References


---

* [x] I have seen and agree to CONTRIBUTING.md
