### PR TITLE
Add eth_executionAddress endpoint

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2333,3 +2333,8 @@ func toHexSlice(b [][]byte) []string {
 	}
 	return r
 }
+
+// ExecutionAddress returns the execution addresseses available in the Kettle.
+func (s *TransactionAPI) ExecutionAddress(ctx context.Context) ([]common.Address, error) {
+	return s.b.AccountManager().Accounts(), nil
+}

--- a/suave/e2e/workflow_test.go
+++ b/suave/e2e/workflow_test.go
@@ -1034,6 +1034,17 @@ func TestE2EPrecompile_Call(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestE2EExecutionAddressEndpoint(t *testing.T) {
+	// this end-to-end tests ensures that we can call eth_executionAddress endpoint in a MEVM node
+	// and return the correct execution address list
+	fr := newFramework(t, WithExecutionNode())
+	defer fr.Close()
+
+	var addrs []common.Address
+	require.NoError(t, fr.suethSrv.RPCNode().Call(&addrs, "eth_executionAddress"))
+	require.NotEmpty(t, addrs)
+}
+
 type clientWrapper struct {
 	t *testing.T
 


### PR DESCRIPTION
## 📝 Summary

This PR introduces a new SUAVE endpoint `eth_executionAddress` which returns the address used by the execution node to fulfill the confidential request.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
