### PR TITLE
add maxBlock to sbundle

### DIFF
--- a/core/types/sbundle.go
+++ b/core/types/sbundle.go
@@ -12,6 +12,7 @@ import (
 
 type SBundle struct {
 	BlockNumber     *big.Int      `json:"blockNumber,omitempty"` // if BlockNumber is set it must match DecryptionCondition!
+	MaxBlock        *big.Int      `json:"maxBlock,omitempty"`
 	Txs             Transactions  `json:"txs"`
 	RevertingHashes []common.Hash `json:"revertingHashes,omitempty"`
 	RefundPercent   *int          `json:"percent,omitempty"`
@@ -19,6 +20,7 @@ type SBundle struct {
 
 type RpcSBundle struct {
 	BlockNumber     *hexutil.Big    `json:"blockNumber,omitempty"`
+	MaxBlock        *hexutil.Big    `json:"maxBlock,omitempty"`
 	Txs             []hexutil.Bytes `json:"txs"`
 	RevertingHashes []common.Hash   `json:"revertingHashes,omitempty"`
 	RefundPercent   *int            `json:"percent,omitempty"`
@@ -66,6 +68,7 @@ func (s *SBundle) UnmarshalJSON(data []byte) error {
 	}
 
 	s.BlockNumber = (*big.Int)(rpcSBundle.BlockNumber)
+	s.MaxBlock = (*big.Int)(rpcSBundle.MaxBlock)
 	s.Txs = txs
 	s.RevertingHashes = rpcSBundle.RevertingHashes
 	s.RefundPercent = rpcSBundle.RefundPercent
@@ -76,7 +79,8 @@ func (s *SBundle) UnmarshalJSON(data []byte) error {
 type RPCMevShareBundle struct {
 	Version   string `json:"version"`
 	Inclusion struct {
-		Block string `json:"block"`
+		Block    string `json:"block"`
+		MaxBlock string `json:"maxBlock"`
 	} `json:"inclusion"`
 	Body []struct {
 		Tx        string `json:"tx"`

--- a/core/vm/contracts_suave_eth.go
+++ b/core/vm/contracts_suave_eth.go
@@ -454,6 +454,7 @@ func (c *suaveRuntime) fillMevShareBundle(bidId types.BidId) ([]byte, error) {
 	}
 
 	shareBundle.Inclusion.Block = hexutil.EncodeUint64(bid.DecryptionCondition)
+	shareBundle.Inclusion.Block = hexutil.EncodeUint64(bid.DecryptionCondition + 25) // Assumes 25 block inclusion range
 
 	for _, tx := range append(userBundle.Txs, matchBundle.Txs...) {
 		txBytes, err := tx.MarshalBinary()

--- a/core/vm/contracts_suave_eth.go
+++ b/core/vm/contracts_suave_eth.go
@@ -454,7 +454,7 @@ func (c *suaveRuntime) fillMevShareBundle(bidId types.BidId) ([]byte, error) {
 	}
 
 	shareBundle.Inclusion.Block = hexutil.EncodeUint64(bid.DecryptionCondition)
-	shareBundle.Inclusion.Block = hexutil.EncodeUint64(bid.DecryptionCondition + 25) // Assumes 25 block inclusion range
+	shareBundle.Inclusion.MaxBlock = hexutil.EncodeUint64(bid.DecryptionCondition + 25) // Assumes 25 block inclusion range
 
 	for _, tx := range append(userBundle.Txs, matchBundle.Txs...) {
 		txBytes, err := tx.MarshalBinary()


### PR DESCRIPTION
## 📝 Summary

when a maxBlock isnt included, the [mev-share protocol](https://github.com/flashbots/mev-share/blob/main/specs/bundles/v0.1.md#inclusion) assumes 1 block validity. This PR adds a `maxBlock = 25`.

## 📚 References

https://github.com/flashbots/mev-share/blob/main/specs/bundles/v0.1.md#inclusion

---

* [x] I have seen and agree to CONTRIBUTING.md
