### PR TITLE
chore: remove http.port flag in dev mode

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -531,7 +531,6 @@ func prepareSuaveDev(ctx *cli.Context) error {
 		utils.DeveloperFlag.Name:         "true",
 		utils.DeveloperGasLimitFlag.Name: "30000000",
 		utils.HTTPEnabledFlag.Name:       "true",
-		utils.HTTPPortFlag.Name:          "8545",
 		utils.HTTPVirtualHostsFlag.Name:  "*",
 		utils.HTTPCORSDomainFlag.Name:    "*",
 		utils.WSEnabledFlag.Name:         "true",


### PR DESCRIPTION
## 📝 Summary

Fixes #124 

Removes the `HTTPPortFlag.Name` so that it doesn't always start `8545` in `dev` mode even when the user has specified the `--http.port`

---

* [x] I have seen and agree to CONTRIBUTING.md
