### PR TITLE
POC : Request results pattern

### DIFF
--- a/suave/sol/standard_peekers/bids.sol
+++ b/suave/sol/standard_peekers/bids.sol
@@ -47,9 +47,16 @@ contract BundleBidContract is AnyBidContract {
 
 contract EthBundleSenderContract is BundleBidContract {
     string[] public builderUrls;
-	bytes[] public submissionResults;
+	SubmissionResults[] public submissionResults;
 
-	event SubmissionEvent(bytes[] submissionResults);
+	event SubmissionEvent(SubmissionResults[] submissionResults);
+
+    struct SubmissionResults {
+        uint64 statusCode;
+        string destination;
+        uint256 roundTripTime;
+        string response;
+    }
 
 
     constructor(string[] memory builderUrls_) {
@@ -71,6 +78,7 @@ contract EthBundleSenderContract is BundleBidContract {
 
         for (uint256 i = 0; i < builderUrls.length; i++) {
 			submissionDetails = Suave.submitBundleJsonRPC(builderUrls[i], "eth_sendBundle", bundleData);
+            (uint64 statusCode, string memory destination, uint256 roundTripTime, string memory response) = abi.decode(submissionDetails, (uint64, string, uint256, string));
             submissionResults.push(submissionDetails);
         }
 		return bytes.concat(this.emitAndReturnWithResults.selector, abi.encode(bid,  submissionResults));


### PR DESCRIPTION
## 📝 Summary

This is a simple PoC of a logging pattern we could use to help display more information in the block explorer to help guide users on their SUAPPs internals.

We could then alter the block explorer to something like this (don't read into the screenshot too much, I simply googled "networking UI" and photo shopped it into a screen shot of the explorer)

<img width="889" alt="Screenshot 2023-12-16 at 2 15 25 PM (2)" src="https://github.com/flashbots/suave-geth/assets/22778355/1b90549b-aa77-4bf6-b1f3-86b6d06a73e8">


## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
