### PR TITLE
Do not move suave binary to GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ suave:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/suave\" to launch SUAVE."
 
-	# Move a copy of the binary to GOPATH/bin
-	cp $(GOBIN)/suave $(GOPATH)/bin
-
 all:
 	$(GORUN) build/ci.go install
 


### PR DESCRIPTION
## 📝 Summary

For the `forge` integration, the `suave` binary must be in `PATH`. During the development of the feature, I added to `make suave` the command to copy the binary. However, this gives warnings and errors because of permission issues.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
