### PR TITLE
Use dockerhub for releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,9 +89,9 @@ dockers:
     build_flag_templates:
       - --platform=linux/amd64
     image_templates:
-      - "ghcr.io/flashbots/suave-geth:{{ .ShortCommit }}"
-      - "ghcr.io/flashbots/suave-geth:{{ .Tag }}"
-      - "ghcr.io/flashbots/suave-geth:latest"
+      - "flashbots/suave-geth:{{ .ShortCommit }}"
+      - "flashbots/suave-geth:{{ .Tag }}"
+      - "flashbots/suave-geth:latest"
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## 📝 Summary

It uses Docker hub and not the GitHub registry for the images.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
