### PR TITLE
Add build flags to create static binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,7 +38,10 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -extldflags "-lc -lrt -lpthread --static"
+      - -extldflags "-Wl,-z,stack-size=0x800000 --static"
+    tags:
+      - netgo
+      - osusergo
   - id: suave-geth-linux-arm64
     binary: suave-geth
     main: ./cmd/geth
@@ -52,7 +55,10 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -extldflags "-lc -lrt -lpthread --static"
+      - -extldflags "-Wl,-z,stack-size=0x800000 --static"
+    tags:
+      - netgo
+      - osusergo
   - id: suave-geth-windows-amd64
     binary: suave-geth
     main: ./cmd/geth


### PR DESCRIPTION
## 📝 Summary

This PR adds the missing build flags to create a complete static binary. Otherwise, the system tries to use dynamic libraries to resolve DNS and it crashes if the libraries are not there (like in CI).

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
