### PR TITLE
Add custom timeout in transaction result sdk

### DIFF
--- a/suave/sdk/sdk.go
+++ b/suave/sdk/sdk.go
@@ -104,11 +104,15 @@ type TransactionResult struct {
 }
 
 func (t *TransactionResult) Wait() (*types.Receipt, error) {
+	return t.WaitWithTimeout(10 * time.Second)
+}
+
+func (t *TransactionResult) WaitWithTimeout(timeout time.Duration) (*types.Receipt, error) {
 	if t.receipt != nil {
 		return t.receipt, nil
 	}
 
-	timer := time.NewTimer(10 * time.Second)
+	timer := time.NewTimer(timeout)
 
 	var receipt *types.Receipt
 	var err error

--- a/suave/sdk/sdk.go
+++ b/suave/sdk/sdk.go
@@ -167,6 +167,10 @@ func (c *Client) getSigner() (types.Signer, error) {
 	return signer, nil
 }
 
+func (c *Client) Addr() common.Address {
+	return crypto.PubkeyToAddress(c.key.PublicKey)
+}
+
 func (c *Client) SignTxn(txn *types.LegacyTx) (*types.Transaction, error) {
 	signer, err := c.getSigner()
 	if err != nil {


### PR DESCRIPTION
## 📝 Summary

This PR adds a custom timeout for mined transactions in the `sdk`. Otherwise, the default timeout is too short for most chains.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
