### PR TITLE
Add remove method to reset the local confidential store

### DIFF
--- a/cmd/geth/forgecmd.go
+++ b/cmd/geth/forgecmd.go
@@ -25,6 +25,7 @@ var (
 		Description: `Internal command used by MEVM precompiles in forge to access the MEVM API utilities.`,
 		Subcommands: []*cli.Command{
 			forgeStatusCmd,
+			resetConfStore,
 		},
 		Action: func(ctx *cli.Context) error {
 			args := ctx.Args()
@@ -125,6 +126,21 @@ var forgeStatusCmd = &cli.Command{
 		var chainID hexutil.Big
 		if err := rpcClient.Call(&chainID, "eth_chainId"); err != nil {
 			return handleErr(err)
+		}
+		return nil
+	},
+}
+
+var resetConfStore = &cli.Command{
+	Name:  "reset-conf-store",
+	Usage: "Internal command to reset the confidential store",
+	Action: func(ctx *cli.Context) error {
+		rpcClient, err := rpc.Dial(defaultRemoteSuaveHost)
+		if err != nil {
+			return err
+		}
+		if err := rpcClient.Call(nil, "suavey_resetConfStore"); err != nil {
+			return err
 		}
 		return nil
 	},

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -537,6 +537,7 @@ func prepareSuaveDev(ctx *cli.Context) error {
 		utils.HTTPVirtualHostsFlag.Name:  "*",
 		utils.HTTPCORSDomainFlag.Name:    "*",
 		utils.HTTPListenAddrFlag.Name:    "0.0.0.0",
+		utils.HTTPApiFlag.Name:           "suavex,debug,suavey,eth",
 		utils.WSEnabledFlag.Name:         "true",
 		utils.WSAllowedOriginsFlag.Name:  "*",
 		utils.WSListenAddrFlag.Name:      "0.0.0.0",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -360,6 +360,12 @@ func (s *Ethereum) APIs() []rpc.API {
 		Service:   suave_builder_api.NewServer(sessionManager),
 	})
 
+	// if in devnet test mode, enable the suave dev jsonrpc endpoint
+	apis = append(apis, rpc.API{
+		Namespace: "suavey",
+		Service:   &backends.SuaveInternalBackend{Cstore: s.APIBackend.SuaveEngine()},
+	})
+
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)
 

--- a/suave/backends/dev_suave_backend.go
+++ b/suave/backends/dev_suave_backend.go
@@ -1,0 +1,21 @@
+package backends
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type confidentialStore interface {
+	Reset() error
+}
+
+// SuaveInternalBackend is a jsonrpc backend for internal suave testing
+type SuaveInternalBackend struct {
+	Cstore confidentialStore
+}
+
+func (d *SuaveInternalBackend) ResetConfStore(ctx context.Context) error {
+	log.Info("Resetting Confidential Store")
+	return d.Cstore.Reset()
+}

--- a/suave/cstore/engine.go
+++ b/suave/cstore/engine.go
@@ -89,6 +89,14 @@ func NewEngine(backend ConfidentialStorageBackend, transportTopic StoreTransport
 	}
 }
 
+func (e *CStoreEngine) Reset() error {
+	if local, ok := e.storage.(*LocalConfidentialStore); ok {
+		// only allow reset for local store
+		return local.Reset()
+	}
+	return nil
+}
+
 // NewTransactionalStore creates a new transactional store.
 func (e *CStoreEngine) NewTransactionalStore(sourceTx *types.Transaction) *TransactionalStore {
 	return &TransactionalStore{
@@ -119,7 +127,7 @@ func (e *CStoreEngine) Start() error {
 // Stop terminates the CStoreEngine.
 func (e *CStoreEngine) Stop() error {
 	if e.cancel == nil {
-		return errors.New("Confidential engine: Stop() called before Start()")
+		return errors.New("confidential engine: Stop() called before Start()")
 	}
 
 	e.cancel()

--- a/suave/cstore/local_store_backend.go
+++ b/suave/cstore/local_store_backend.go
@@ -27,6 +27,17 @@ func NewLocalConfidentialStore() *LocalConfidentialStore {
 	}
 }
 
+func (l *LocalConfidentialStore) Reset() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	l.records = make(map[suave.DataId]suave.DataRecord)
+	l.dataMap = make(map[string][]byte)
+	l.index = make(map[string][]suave.DataId)
+
+	return nil
+}
+
 func (l *LocalConfidentialStore) Stop() error {
 	return nil
 }

--- a/suave/cstore/redis_store_backend.go
+++ b/suave/cstore/redis_store_backend.go
@@ -84,7 +84,7 @@ func (r *RedisStoreBackend) start() error {
 
 func (r *RedisStoreBackend) Stop() error {
 	if r.cancel == nil || r.client == nil {
-		return errors.New("Redis store: Stop() called before Start()")
+		return errors.New("redis store: Stop() called before Start()")
 	}
 
 	if r.local != nil {

--- a/suave/cstore/redis_transport.go
+++ b/suave/cstore/redis_transport.go
@@ -57,7 +57,7 @@ func (r *RedisPubSubTransport) Start() error {
 
 func (r *RedisPubSubTransport) Stop() error {
 	if r.cancel == nil || r.client == nil {
-		return errors.New("Redis pubsub: Stop() called before Start()")
+		return errors.New("redis pubsub: Stop() called before Start()")
 	}
 
 	r.cancel()


### PR DESCRIPTION
## 📝 Summary

This PR adds four things:
- A new **internal** namespace called `suavey` only enabled during development intended to expose methods for testing utilities. The new namespace is enabled when `--suave.dev` is set.
- A function for the in-memory confidential store (used by `--suave.dev`) to reset the internal state.
- A method `suavey_resetConfStore` that resets the confidential store.
- A command `suave-geth forge reset-conf-store` that calls the `suavey_resetConfStore` method.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
