### PR TITLE
Limit number of open sessions

### DIFF
--- a/suave/builder/api/api_server.go
+++ b/suave/builder/api/api_server.go
@@ -6,13 +6,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// sessionManager is the backend that manages the session state of the builder API.
-type sessionManager interface {
-	NewSession() (string, error)
+// SessionManager is the backend that manages the session state of the builder API.
+type SessionManager interface {
+	NewSession(context.Context) (string, error)
 	AddTransaction(sessionId string, tx *types.Transaction) (*types.SimulateTransactionResult, error)
 }
 
-func NewServer(s sessionManager) *Server {
+func NewServer(s SessionManager) *Server {
 	api := &Server{
 		sessionMngr: s,
 	}
@@ -20,11 +20,11 @@ func NewServer(s sessionManager) *Server {
 }
 
 type Server struct {
-	sessionMngr sessionManager
+	sessionMngr SessionManager
 }
 
 func (s *Server) NewSession(ctx context.Context) (string, error) {
-	return s.sessionMngr.NewSession()
+	return s.sessionMngr.NewSession(ctx)
 }
 
 func (s *Server) AddTransaction(ctx context.Context, sessionId string, tx *types.Transaction) (*types.SimulateTransactionResult, error) {

--- a/suave/builder/api/api_test.go
+++ b/suave/builder/api/api_test.go
@@ -30,10 +30,10 @@ func TestAPI(t *testing.T) {
 
 type nullSessionManager struct{}
 
-func (n *nullSessionManager) NewSession() (string, error) {
-	return "1", nil
+func (nullSessionManager) NewSession(ctx context.Context) (string, error) {
+	return "1", ctx.Err()
 }
 
-func (n *nullSessionManager) AddTransaction(sessionId string, tx *types.Transaction) (*types.SimulateTransactionResult, error) {
+func (nullSessionManager) AddTransaction(sessionId string, tx *types.Transaction) (*types.SimulateTransactionResult, error) {
 	return &types.SimulateTransactionResult{Logs: []*types.SimulatedLog{}}, nil
 }

--- a/suave/builder/session_manager.go
+++ b/suave/builder/session_manager.go
@@ -73,6 +73,9 @@ func (s *SessionManager) NewSession(ctx context.Context) (string, error) {
 		}
 
 		s.sem = make(chan struct{}, s.MaxConcurrentSessions)
+		for len(s.sem) < cap(s.sem) {
+			s.sem <- struct{}{} // fill 'er up
+		}
 	})
 
 	// Wait for session to become available

--- a/suave/builder/session_manager.go
+++ b/suave/builder/session_manager.go
@@ -32,15 +32,13 @@ type blockchain interface {
 }
 
 type Config struct {
-	GasCeil            uint64
-	SessionIdleTimeout time.Duration
+	GasCeil               uint64
+	SessionIdleTimeout    time.Duration
+	MaxConcurrentSessions int
 }
 
 type SessionManager struct {
-	once                  sync.Once
-	MaxConcurrentSessions int
-	sem                   chan struct{}
-
+	sem           chan struct{}
 	sessions      map[string]*builder
 	sessionTimers map[string]*time.Timer
 	sessionsLock  sync.RWMutex
@@ -55,8 +53,17 @@ func NewSessionManager(blockchain blockchain, config *Config) *SessionManager {
 	if config.SessionIdleTimeout == 0 {
 		config.SessionIdleTimeout = 5 * time.Second
 	}
+	if config.MaxConcurrentSessions <= 0 {
+		config.MaxConcurrentSessions = 16 // chosen arbitrarily
+	}
+
+	sem := make(chan struct{}, config.MaxConcurrentSessions)
+	for len(sem) < cap(sem) {
+		sem <- struct{}{} // fill 'er up
+	}
 
 	s := &SessionManager{
+		sem:           sem,
 		sessions:      make(map[string]*builder),
 		sessionTimers: make(map[string]*time.Timer),
 		blockchain:    blockchain,
@@ -67,17 +74,6 @@ func NewSessionManager(blockchain blockchain, config *Config) *SessionManager {
 
 // NewSession creates a new builder session and returns the session id
 func (s *SessionManager) NewSession(ctx context.Context) (string, error) {
-	s.once.Do(func() {
-		if s.MaxConcurrentSessions <= 0 {
-			s.MaxConcurrentSessions = 16 // chosen arbitrarily
-		}
-
-		s.sem = make(chan struct{}, s.MaxConcurrentSessions)
-		for len(s.sem) < cap(s.sem) {
-			s.sem <- struct{}{} // fill 'er up
-		}
-	})
-
 	// Wait for session to become available
 	select {
 	case <-s.sem:

--- a/suave/builder/session_manager_test.go
+++ b/suave/builder/session_manager_test.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"math/big"
 	"testing"
@@ -21,7 +22,7 @@ func TestSessionManager_SessionTimeout(t *testing.T) {
 		SessionIdleTimeout: 500 * time.Millisecond,
 	})
 
-	id, err := mngr.NewSession()
+	id, err := mngr.NewSession(context.TODO())
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)
@@ -35,7 +36,7 @@ func TestSessionManager_SessionRefresh(t *testing.T) {
 		SessionIdleTimeout: 500 * time.Millisecond,
 	})
 
-	id, err := mngr.NewSession()
+	id, err := mngr.NewSession(context.TODO())
 	require.NoError(t, err)
 
 	// if we query the session under the idle timeout,
@@ -60,7 +61,7 @@ func TestSessionManager_StartSession(t *testing.T) {
 	// test that the session starts and it can simulate transactions
 	mngr, bMock := newSessionManager(t, &Config{})
 
-	id, err := mngr.NewSession()
+	id, err := mngr.NewSession(context.TODO())
 	require.NoError(t, err)
 
 	txn := bMock.state.newTransfer(t, common.Address{}, big.NewInt(1))

--- a/suave/builder/session_manager_test.go
+++ b/suave/builder/session_manager_test.go
@@ -34,9 +34,11 @@ func TestSessionManager_SessionTimeout(t *testing.T) {
 func TestSessionManager_MaxConcurrentSessions(t *testing.T) {
 	t.Parallel()
 
+	const d = time.Millisecond * 10
+
 	mngr, _ := newSessionManager(t, &Config{
 		MaxConcurrentSessions: 1,
-		SessionIdleTimeout:    500 * time.Millisecond,
+		SessionIdleTimeout:    d,
 	})
 
 	t.Run("SessionAvailable", func(t *testing.T) {
@@ -52,6 +54,15 @@ func TestSessionManager_MaxConcurrentSessions(t *testing.T) {
 		sess, err := mngr.NewSession(ctx)
 		require.Zero(t, sess)
 		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("SessionExpired", func(t *testing.T) {
+		time.Sleep(d) // Wait for the session to expire.
+
+		// We should be able to open a session again.
+		sess, err := mngr.NewSession(context.TODO())
+		require.NoError(t, err)
+		require.NotZero(t, sess)
 	})
 }
 


### PR DESCRIPTION
## 📝 Summary

Use a semaphore channel to limit the number of open sessions. This is a hack because we're relying on session timeout behavior. Recommend ref-counting API that releases refs when block-height changes in near-term future.

Resolves #153 

## 📚 References

---

* [x] I have seen and agree to CONTRIBUTING.md
