### PR TITLE
Remove ccr object from core/vm

### DIFF
--- a/core/vm/contracts_suave.go
+++ b/core/vm/contracts_suave.go
@@ -90,10 +90,6 @@ func (b *suaveRuntime) confidentialRetrieve(dataId types.DataId, key string) ([]
 /* Data Record precompiles */
 
 func (b *suaveRuntime) newDataRecord(decryptionCondition uint64, allowedPeekers []common.Address, allowedStores []common.Address, RecordType string) (types.DataRecord, error) {
-	if b.suaveContext.ConfidentialComputeRequestTx == nil {
-		panic("newRecord: source transaction not present")
-	}
-
 	record, err := b.suaveContext.Backend.ConfidentialStore.InitRecord(types.DataRecord{
 		Salt:                suave.RandomDataRecordId(),
 		DecryptionCondition: decryptionCondition,

--- a/core/vm/contracts_suave_test.go
+++ b/core/vm/contracts_suave_test.go
@@ -95,7 +95,6 @@ func newTestBackend(t *testing.T) *suaveRuntime {
 				ConfidentialStore:      confEngine.NewTransactionalStore(reqTx),
 				ConfidentialEthBackend: &mockSuaveBackend{},
 			},
-			ConfidentialComputeRequestTx: reqTx,
 		},
 	}
 	return b

--- a/core/vm/suave.go
+++ b/core/vm/suave.go
@@ -22,14 +22,14 @@ type ConfidentialStore interface {
 	Retrieve(record types.DataId, caller common.Address, key string) ([]byte, error)
 	FetchRecordByID(suave.DataId) (suave.DataRecord, error)
 	FetchRecordsByProtocolAndBlock(blockNumber uint64, namespace string) []suave.DataRecord
+	Finalize() error
 }
 
 type SuaveContext struct {
 	// TODO: MEVM access to Backend should be restricted to only the necessary functions!
-	Backend                      *SuaveExecutionBackend
-	ConfidentialComputeRequestTx *types.Transaction
-	ConfidentialInputs           []byte
-	CallerStack                  []*common.Address
+	Backend            *SuaveExecutionBackend
+	ConfidentialInputs []byte
+	CallerStack        []*common.Address
 }
 
 type SuaveExecutionBackend struct {
@@ -46,10 +46,9 @@ func NewRuntimeSuaveContext(evm *EVM, caller common.Address) *SuaveContext {
 	}
 
 	return &SuaveContext{
-		Backend:                      evm.SuaveContext.Backend,
-		ConfidentialComputeRequestTx: evm.SuaveContext.ConfidentialComputeRequestTx,
-		ConfidentialInputs:           evm.SuaveContext.ConfidentialInputs,
-		CallerStack:                  append(evm.SuaveContext.CallerStack, &caller),
+		Backend:            evm.SuaveContext.Backend,
+		ConfidentialInputs: evm.SuaveContext.ConfidentialInputs,
+		CallerStack:        append(evm.SuaveContext.CallerStack, &caller),
 	}
 }
 

--- a/suave/cstore/transactional_store.go
+++ b/suave/cstore/transactional_store.go
@@ -95,6 +95,10 @@ func (s *TransactionalStore) Retrieve(dataId suave.DataId, caller common.Address
 
 // InitRecord prepares a data record for storage.
 func (s *TransactionalStore) InitRecord(rawRecord types.DataRecord) (types.DataRecord, error) {
+	if s.sourceTx == nil {
+		return types.DataRecord{}, errors.New("confidential store transaction: no source transaction")
+	}
+
 	record, err := s.engine.InitRecord(rawRecord, s.sourceTx)
 	if err != nil {
 		return types.DataRecord{}, err


### PR DESCRIPTION
## 📝 Summary

This PR removes the `types.Transaction` object from the `core/vm` execution since it was only used to validate that it exists during new record creation. But, the transaction store that creates the new records already has a reference to this transaction that can be used instead.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
