### PR TITLE
Use call instead of delegate call in precompile calls

### DIFF
--- a/suave/gen/main.go
+++ b/suave/gen/main.go
@@ -397,7 +397,7 @@ address public constant {{encodeAddrName .Name}} =
 {{end}}
 
 // Returns whether execution is off- or on-chain
-function isConfidential() internal view returns (bool b) {
+function isConfidential() internal returns (bool b) {
 	(bool success, bytes memory isConfidentialBytes) = IS_CONFIDENTIAL_ADDR.call("");
 	if (!success) {
 		revert PeekerReverted(IS_CONFIDENTIAL_ADDR, isConfidentialBytes);
@@ -411,7 +411,7 @@ function isConfidential() internal view returns (bool b) {
 }
 
 {{range .Functions}}
-function {{.Name}}({{range .Input}}{{styp .Typ}} {{.Name}}, {{end}}) internal view returns ({{range .Output.Fields}}{{styp .Typ}}, {{end}}) {
+function {{.Name}}({{range .Input}}{{styp .Typ}} {{.Name}}, {{end}}) internal returns ({{range .Output.Fields}}{{styp .Typ}}, {{end}}) {
 	{{if .IsConfidential}}require(isConfidential());{{end}}
 	(bool success, bytes memory data) = {{encodeAddrName .Name}}.call(abi.encode({{range .Input}}{{.Name}}, {{end}}));
 	if (!success) {

--- a/suave/gen/main.go
+++ b/suave/gen/main.go
@@ -413,7 +413,7 @@ function isConfidential() internal view returns (bool b) {
 {{range .Functions}}
 function {{.Name}}({{range .Input}}{{styp .Typ}} {{.Name}}, {{end}}) internal view returns ({{range .Output.Fields}}{{styp .Typ}}, {{end}}) {
 	{{if .IsConfidential}}require(isConfidential());{{end}}
-	(bool success, bytes memory data) = {{encodeAddrName .Name}}.staticcall(abi.encode({{range .Input}}{{.Name}}, {{end}}));
+	(bool success, bytes memory data) = {{encodeAddrName .Name}}.call(abi.encode({{range .Input}}{{.Name}}, {{end}}));
 	if (!success) {
 		revert PeekerReverted({{encodeAddrName .Name}}, data);
 	}

--- a/suave/gen/main.go
+++ b/suave/gen/main.go
@@ -398,7 +398,7 @@ address public constant {{encodeAddrName .Name}} =
 
 // Returns whether execution is off- or on-chain
 function isConfidential() internal view returns (bool b) {
-	(bool success, bytes memory isConfidentialBytes) = IS_CONFIDENTIAL_ADDR.staticcall("");
+	(bool success, bytes memory isConfidentialBytes) = IS_CONFIDENTIAL_ADDR.call("");
 	if (!success) {
 		revert PeekerReverted(IS_CONFIDENTIAL_ADDR, isConfidentialBytes);
 	}

--- a/suave/sol/libraries/Suave.sol
+++ b/suave/sol/libraries/Suave.sol
@@ -96,7 +96,7 @@ library Suave {
 
     // Returns whether execution is off- or on-chain
     function isConfidential() internal view returns (bool b) {
-        (bool success, bytes memory isConfidentialBytes) = IS_CONFIDENTIAL_ADDR.staticcall("");
+        (bool success, bytes memory isConfidentialBytes) = IS_CONFIDENTIAL_ADDR.call("");
         if (!success) {
             revert PeekerReverted(IS_CONFIDENTIAL_ADDR, isConfidentialBytes);
         }

--- a/suave/sol/libraries/Suave.sol
+++ b/suave/sol/libraries/Suave.sol
@@ -95,7 +95,7 @@ library Suave {
     address public constant SUBMIT_ETH_BLOCK_TO_RELAY = 0x0000000000000000000000000000000042100002;
 
     // Returns whether execution is off- or on-chain
-    function isConfidential() internal view returns (bool b) {
+    function isConfidential() internal returns (bool b) {
         (bool success, bytes memory isConfidentialBytes) = IS_CONFIDENTIAL_ADDR.call("");
         if (!success) {
             revert PeekerReverted(IS_CONFIDENTIAL_ADDR, isConfidentialBytes);
@@ -110,7 +110,6 @@ library Suave {
 
     function buildEthBlock(BuildBlockArgs memory blockArgs, DataId dataId, string memory namespace)
         internal
-        view
         returns (bytes memory, bytes memory)
     {
         (bool success, bytes memory data) = BUILD_ETH_BLOCK.call(abi.encode(blockArgs, dataId, namespace));
@@ -121,7 +120,7 @@ library Suave {
         return abi.decode(data, (bytes, bytes));
     }
 
-    function confidentialInputs() internal view returns (bytes memory) {
+    function confidentialInputs() internal returns (bytes memory) {
         (bool success, bytes memory data) = CONFIDENTIAL_INPUTS.call(abi.encode());
         if (!success) {
             revert PeekerReverted(CONFIDENTIAL_INPUTS, data);
@@ -130,7 +129,7 @@ library Suave {
         return data;
     }
 
-    function confidentialRetrieve(DataId dataId, string memory key) internal view returns (bytes memory) {
+    function confidentialRetrieve(DataId dataId, string memory key) internal returns (bytes memory) {
         (bool success, bytes memory data) = CONFIDENTIAL_RETRIEVE.call(abi.encode(dataId, key));
         if (!success) {
             revert PeekerReverted(CONFIDENTIAL_RETRIEVE, data);
@@ -139,14 +138,14 @@ library Suave {
         return data;
     }
 
-    function confidentialStore(DataId dataId, string memory key, bytes memory value) internal view {
+    function confidentialStore(DataId dataId, string memory key, bytes memory value) internal {
         (bool success, bytes memory data) = CONFIDENTIAL_STORE.call(abi.encode(dataId, key, value));
         if (!success) {
             revert PeekerReverted(CONFIDENTIAL_STORE, data);
         }
     }
 
-    function doHTTPRequest(HttpRequest memory request) internal view returns (bytes memory) {
+    function doHTTPRequest(HttpRequest memory request) internal returns (bytes memory) {
         (bool success, bytes memory data) = DO_HTTPREQUEST.call(abi.encode(request));
         if (!success) {
             revert PeekerReverted(DO_HTTPREQUEST, data);
@@ -155,7 +154,7 @@ library Suave {
         return abi.decode(data, (bytes));
     }
 
-    function ethcall(address contractAddr, bytes memory input1) internal view returns (bytes memory) {
+    function ethcall(address contractAddr, bytes memory input1) internal returns (bytes memory) {
         (bool success, bytes memory data) = ETHCALL.call(abi.encode(contractAddr, input1));
         if (!success) {
             revert PeekerReverted(ETHCALL, data);
@@ -164,7 +163,7 @@ library Suave {
         return abi.decode(data, (bytes));
     }
 
-    function extractHint(bytes memory bundleData) internal view returns (bytes memory) {
+    function extractHint(bytes memory bundleData) internal returns (bytes memory) {
         require(isConfidential());
         (bool success, bytes memory data) = EXTRACT_HINT.call(abi.encode(bundleData));
         if (!success) {
@@ -174,7 +173,7 @@ library Suave {
         return data;
     }
 
-    function fetchDataRecords(uint64 cond, string memory namespace) internal view returns (DataRecord[] memory) {
+    function fetchDataRecords(uint64 cond, string memory namespace) internal returns (DataRecord[] memory) {
         (bool success, bytes memory data) = FETCH_DATA_RECORDS.call(abi.encode(cond, namespace));
         if (!success) {
             revert PeekerReverted(FETCH_DATA_RECORDS, data);
@@ -183,7 +182,7 @@ library Suave {
         return abi.decode(data, (DataRecord[]));
     }
 
-    function fillMevShareBundle(DataId dataId) internal view returns (bytes memory) {
+    function fillMevShareBundle(DataId dataId) internal returns (bytes memory) {
         require(isConfidential());
         (bool success, bytes memory data) = FILL_MEV_SHARE_BUNDLE.call(abi.encode(dataId));
         if (!success) {
@@ -193,7 +192,7 @@ library Suave {
         return data;
     }
 
-    function newBuilder() internal view returns (string memory) {
+    function newBuilder() internal returns (string memory) {
         (bool success, bytes memory data) = NEW_BUILDER.call(abi.encode());
         if (!success) {
             revert PeekerReverted(NEW_BUILDER, data);
@@ -207,7 +206,7 @@ library Suave {
         address[] memory allowedPeekers,
         address[] memory allowedStores,
         string memory dataType
-    ) internal view returns (DataRecord memory) {
+    ) internal returns (DataRecord memory) {
         (bool success, bytes memory data) =
             NEW_DATA_RECORD.call(abi.encode(decryptionCondition, allowedPeekers, allowedStores, dataType));
         if (!success) {
@@ -219,7 +218,6 @@ library Suave {
 
     function signEthTransaction(bytes memory txn, string memory chainId, string memory signingKey)
         internal
-        view
         returns (bytes memory)
     {
         (bool success, bytes memory data) = SIGN_ETH_TRANSACTION.call(abi.encode(txn, chainId, signingKey));
@@ -230,7 +228,7 @@ library Suave {
         return abi.decode(data, (bytes));
     }
 
-    function signMessage(bytes memory digest, string memory signingKey) internal view returns (bytes memory) {
+    function signMessage(bytes memory digest, string memory signingKey) internal returns (bytes memory) {
         require(isConfidential());
         (bool success, bytes memory data) = SIGN_MESSAGE.call(abi.encode(digest, signingKey));
         if (!success) {
@@ -240,7 +238,7 @@ library Suave {
         return abi.decode(data, (bytes));
     }
 
-    function simulateBundle(bytes memory bundleData) internal view returns (uint64) {
+    function simulateBundle(bytes memory bundleData) internal returns (uint64) {
         (bool success, bytes memory data) = SIMULATE_BUNDLE.call(abi.encode(bundleData));
         if (!success) {
             revert PeekerReverted(SIMULATE_BUNDLE, data);
@@ -251,7 +249,6 @@ library Suave {
 
     function simulateTransaction(string memory sessionid, bytes memory txn)
         internal
-        view
         returns (SimulateTransactionResult memory)
     {
         (bool success, bytes memory data) = SIMULATE_TRANSACTION.call(abi.encode(sessionid, txn));
@@ -264,7 +261,6 @@ library Suave {
 
     function submitBundleJsonRPC(string memory url, string memory method, bytes memory params)
         internal
-        view
         returns (bytes memory)
     {
         require(isConfidential());
@@ -276,11 +272,7 @@ library Suave {
         return data;
     }
 
-    function submitEthBlockToRelay(string memory relayUrl, bytes memory builderBid)
-        internal
-        view
-        returns (bytes memory)
-    {
+    function submitEthBlockToRelay(string memory relayUrl, bytes memory builderBid) internal returns (bytes memory) {
         require(isConfidential());
         (bool success, bytes memory data) = SUBMIT_ETH_BLOCK_TO_RELAY.call(abi.encode(relayUrl, builderBid));
         if (!success) {

--- a/suave/sol/libraries/Suave.sol
+++ b/suave/sol/libraries/Suave.sol
@@ -113,7 +113,7 @@ library Suave {
         view
         returns (bytes memory, bytes memory)
     {
-        (bool success, bytes memory data) = BUILD_ETH_BLOCK.staticcall(abi.encode(blockArgs, dataId, namespace));
+        (bool success, bytes memory data) = BUILD_ETH_BLOCK.call(abi.encode(blockArgs, dataId, namespace));
         if (!success) {
             revert PeekerReverted(BUILD_ETH_BLOCK, data);
         }
@@ -122,7 +122,7 @@ library Suave {
     }
 
     function confidentialInputs() internal view returns (bytes memory) {
-        (bool success, bytes memory data) = CONFIDENTIAL_INPUTS.staticcall(abi.encode());
+        (bool success, bytes memory data) = CONFIDENTIAL_INPUTS.call(abi.encode());
         if (!success) {
             revert PeekerReverted(CONFIDENTIAL_INPUTS, data);
         }
@@ -131,7 +131,7 @@ library Suave {
     }
 
     function confidentialRetrieve(DataId dataId, string memory key) internal view returns (bytes memory) {
-        (bool success, bytes memory data) = CONFIDENTIAL_RETRIEVE.staticcall(abi.encode(dataId, key));
+        (bool success, bytes memory data) = CONFIDENTIAL_RETRIEVE.call(abi.encode(dataId, key));
         if (!success) {
             revert PeekerReverted(CONFIDENTIAL_RETRIEVE, data);
         }
@@ -140,14 +140,14 @@ library Suave {
     }
 
     function confidentialStore(DataId dataId, string memory key, bytes memory value) internal view {
-        (bool success, bytes memory data) = CONFIDENTIAL_STORE.staticcall(abi.encode(dataId, key, value));
+        (bool success, bytes memory data) = CONFIDENTIAL_STORE.call(abi.encode(dataId, key, value));
         if (!success) {
             revert PeekerReverted(CONFIDENTIAL_STORE, data);
         }
     }
 
     function doHTTPRequest(HttpRequest memory request) internal view returns (bytes memory) {
-        (bool success, bytes memory data) = DO_HTTPREQUEST.staticcall(abi.encode(request));
+        (bool success, bytes memory data) = DO_HTTPREQUEST.call(abi.encode(request));
         if (!success) {
             revert PeekerReverted(DO_HTTPREQUEST, data);
         }
@@ -156,7 +156,7 @@ library Suave {
     }
 
     function ethcall(address contractAddr, bytes memory input1) internal view returns (bytes memory) {
-        (bool success, bytes memory data) = ETHCALL.staticcall(abi.encode(contractAddr, input1));
+        (bool success, bytes memory data) = ETHCALL.call(abi.encode(contractAddr, input1));
         if (!success) {
             revert PeekerReverted(ETHCALL, data);
         }
@@ -166,7 +166,7 @@ library Suave {
 
     function extractHint(bytes memory bundleData) internal view returns (bytes memory) {
         require(isConfidential());
-        (bool success, bytes memory data) = EXTRACT_HINT.staticcall(abi.encode(bundleData));
+        (bool success, bytes memory data) = EXTRACT_HINT.call(abi.encode(bundleData));
         if (!success) {
             revert PeekerReverted(EXTRACT_HINT, data);
         }
@@ -175,7 +175,7 @@ library Suave {
     }
 
     function fetchDataRecords(uint64 cond, string memory namespace) internal view returns (DataRecord[] memory) {
-        (bool success, bytes memory data) = FETCH_DATA_RECORDS.staticcall(abi.encode(cond, namespace));
+        (bool success, bytes memory data) = FETCH_DATA_RECORDS.call(abi.encode(cond, namespace));
         if (!success) {
             revert PeekerReverted(FETCH_DATA_RECORDS, data);
         }
@@ -185,7 +185,7 @@ library Suave {
 
     function fillMevShareBundle(DataId dataId) internal view returns (bytes memory) {
         require(isConfidential());
-        (bool success, bytes memory data) = FILL_MEV_SHARE_BUNDLE.staticcall(abi.encode(dataId));
+        (bool success, bytes memory data) = FILL_MEV_SHARE_BUNDLE.call(abi.encode(dataId));
         if (!success) {
             revert PeekerReverted(FILL_MEV_SHARE_BUNDLE, data);
         }
@@ -194,7 +194,7 @@ library Suave {
     }
 
     function newBuilder() internal view returns (string memory) {
-        (bool success, bytes memory data) = NEW_BUILDER.staticcall(abi.encode());
+        (bool success, bytes memory data) = NEW_BUILDER.call(abi.encode());
         if (!success) {
             revert PeekerReverted(NEW_BUILDER, data);
         }
@@ -209,7 +209,7 @@ library Suave {
         string memory dataType
     ) internal view returns (DataRecord memory) {
         (bool success, bytes memory data) =
-            NEW_DATA_RECORD.staticcall(abi.encode(decryptionCondition, allowedPeekers, allowedStores, dataType));
+            NEW_DATA_RECORD.call(abi.encode(decryptionCondition, allowedPeekers, allowedStores, dataType));
         if (!success) {
             revert PeekerReverted(NEW_DATA_RECORD, data);
         }
@@ -222,7 +222,7 @@ library Suave {
         view
         returns (bytes memory)
     {
-        (bool success, bytes memory data) = SIGN_ETH_TRANSACTION.staticcall(abi.encode(txn, chainId, signingKey));
+        (bool success, bytes memory data) = SIGN_ETH_TRANSACTION.call(abi.encode(txn, chainId, signingKey));
         if (!success) {
             revert PeekerReverted(SIGN_ETH_TRANSACTION, data);
         }
@@ -232,7 +232,7 @@ library Suave {
 
     function signMessage(bytes memory digest, string memory signingKey) internal view returns (bytes memory) {
         require(isConfidential());
-        (bool success, bytes memory data) = SIGN_MESSAGE.staticcall(abi.encode(digest, signingKey));
+        (bool success, bytes memory data) = SIGN_MESSAGE.call(abi.encode(digest, signingKey));
         if (!success) {
             revert PeekerReverted(SIGN_MESSAGE, data);
         }
@@ -241,7 +241,7 @@ library Suave {
     }
 
     function simulateBundle(bytes memory bundleData) internal view returns (uint64) {
-        (bool success, bytes memory data) = SIMULATE_BUNDLE.staticcall(abi.encode(bundleData));
+        (bool success, bytes memory data) = SIMULATE_BUNDLE.call(abi.encode(bundleData));
         if (!success) {
             revert PeekerReverted(SIMULATE_BUNDLE, data);
         }
@@ -254,7 +254,7 @@ library Suave {
         view
         returns (SimulateTransactionResult memory)
     {
-        (bool success, bytes memory data) = SIMULATE_TRANSACTION.staticcall(abi.encode(sessionid, txn));
+        (bool success, bytes memory data) = SIMULATE_TRANSACTION.call(abi.encode(sessionid, txn));
         if (!success) {
             revert PeekerReverted(SIMULATE_TRANSACTION, data);
         }
@@ -268,7 +268,7 @@ library Suave {
         returns (bytes memory)
     {
         require(isConfidential());
-        (bool success, bytes memory data) = SUBMIT_BUNDLE_JSON_RPC.staticcall(abi.encode(url, method, params));
+        (bool success, bytes memory data) = SUBMIT_BUNDLE_JSON_RPC.call(abi.encode(url, method, params));
         if (!success) {
             revert PeekerReverted(SUBMIT_BUNDLE_JSON_RPC, data);
         }
@@ -282,7 +282,7 @@ library Suave {
         returns (bytes memory)
     {
         require(isConfidential());
-        (bool success, bytes memory data) = SUBMIT_ETH_BLOCK_TO_RELAY.staticcall(abi.encode(relayUrl, builderBid));
+        (bool success, bytes memory data) = SUBMIT_ETH_BLOCK_TO_RELAY.call(abi.encode(relayUrl, builderBid));
         if (!success) {
             revert PeekerReverted(SUBMIT_ETH_BLOCK_TO_RELAY, data);
         }

--- a/suave/sol/standard_peekers/bundles.sol
+++ b/suave/sol/standard_peekers/bundles.sol
@@ -307,7 +307,7 @@ contract EthBlockContract is AnyBundleContract {
         uint64 blockHeight,
         Suave.DataId[] memory records,
         string memory namespace
-    ) public view returns (Suave.DataRecord memory, bytes memory) {
+    ) public returns (Suave.DataRecord memory, bytes memory) {
         address[] memory allowedPeekers = new address[](2);
         allowedPeekers[0] = address(this);
         allowedPeekers[1] = Suave.BUILD_ETH_BLOCK;
@@ -331,7 +331,7 @@ contract EthBlockContract is AnyBundleContract {
         return (dataRecord, builderBid);
     }
 
-    function unlock(Suave.DataId dataId, bytes memory signedBlindedHeader) public view returns (bytes memory) {
+    function unlock(Suave.DataId dataId, bytes memory signedBlindedHeader) public returns (bytes memory) {
         require(Suave.isConfidential());
 
         // TODO: verify the header is correct


### PR DESCRIPTION
## 📝 Summary

This PR replaces the `staticCall` with a normal `call` when a Suave precompile is called. This does not affect the security model since precompiles cannot access state anyway (`staticCall` reverts if the contract tries to update a state variable).

But, it is helpful for the forge integration to make a mock ConfidentialStore in Solidity and use it as the target of the precompiles.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
