### PR TITLE
Validate version and tag match during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,15 @@ jobs:
       - name: Log tag name
         run: echo "Build for tag ${{ github.ref_name }}"
 
+      - name: Validate tag and version
+        run: |
+          make suave
+          version=$(./build/bin/suave-geth version | grep '^Version:' | awk -F': ' '{print "v" $2}')
+          if [ "$version" != "${{ github.ref_name }}" ]; then
+            echo "Version mismatch: $version != ${{ github.ref_name }}"
+            exit 1
+          fi
+
       - name: Create release
         run: make release
         env:


### PR DESCRIPTION
## 📝 Summary

This PR adds a validation step to check that the version that suave-geth returns matches the one from the tag.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
