### PR TITLE
Start release cycle for v0.1.3.

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 0  // Major version component of the current release
-	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 1  // Patch version component of the current release
-	VersionMeta  = "" // Version metadata to append to the version string
+	VersionMajor = 0     // Major version component of the current release
+	VersionMinor = 1     // Minor version component of the current release
+	VersionPatch = 3     // Patch version component of the current release
+	VersionMeta  = "dev" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
## 📝 Summary

After the release of `v0.1.2` this PR starts the release cycle for `v0.1.3`.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
