### PR TITLE
fix args in suave-enabled-chain (devenv) docker-compose

### DIFF
--- a/suave/devenv/docker-compose.yml
+++ b/suave/devenv/docker-compose.yml
@@ -31,6 +31,15 @@ services:
       - --dev
       - --dev.gaslimit=30000000
       - --http
+      - --http.port=8545
+      - --http.addr=0.0.0.0
+      - --http.vhosts=*
+      - --http.corsdomain=*
       - --ws
+      - --ws.origins=*
+      - --ws.addr=0.0.0.0
+      - --keystore=/keystore/keystore
+    volumes:
+      - ./suave-ex-node:/keystore
     ports:
       - 8555:8545


### PR DESCRIPTION
## 📝 Summary

**Problem:** can't hit the execution node (suave-enabled-chain).
request:
```sh
# assuming devenv stack is running via docker-compose
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true],"id":1}' -H "Content-Type: application/json"  http://localhost:8555
```
response:
```txt
curl: (56) Recv failure: Connection reset by peer
```

**Solution:** changes to `suave-enabled-chain` in docker-compose:

- hosts JSON-RPC APIs on 0.0.0.0, needed for the node to listen outside the container
- opens up CORS
- maps the local suave-ex-node directory to access the keystore file

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
