### PR TITLE
add missing arg to mevm in devenv docker-compose + always pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ suavedevtools:
 	go run ./suave/gen/main.go -write
 
 devnet-up:
-	docker-compose -f ./suave/devenv/docker-compose.yml up -d --build
+	docker-compose -f ./suave/devenv/docker-compose.yml up -d --build --pull always
 
 devnet-down:
 	docker-compose -f ./suave/devenv/docker-compose.yml down

--- a/suave/devenv/docker-compose.yml
+++ b/suave/devenv/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - --keystore=/keystore/keystore
       - --unlock=0xB5fEAfbDD752ad52Afb7e1bD2E40432A485bBB7F
       - --password=/keystore/password.txt
+      - --suave.eth.remote_endpoint=http://172.17.0.1:8555
     depends_on:
       - suave-enabled-chain
     volumes:


### PR DESCRIPTION
## 📝 Summary

- adds `--suave.eth.remote_endpoint` flag to mevm in devenv docker-compose to allow it to reach suave-enabled-chain
- adds a flag in `make devnet-up` that always pulls images before running, to ensure users get the latest release automatically

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
