### PR TITLE
Fix forgecmd read empty config from forge.toml

### DIFF
--- a/cmd/geth/forgecmd.go
+++ b/cmd/geth/forgecmd.go
@@ -82,7 +82,10 @@ func readContext(ctx *cli.Context) (*vm.SuaveContext, error) {
 		if err := tomlConfig.NewDecoder(bytes.NewReader(data)).Decode(&config); err != nil {
 			return nil, err
 		}
-		cfg = config.Profile.Suave
+		if config.Profile.Suave != nil {
+			// Only apply the suave config if it exists
+			cfg = config.Profile.Suave
+		}
 	}
 
 	// override the config if the flags are set

--- a/cmd/geth/forgecmd_test.go
+++ b/cmd/geth/forgecmd_test.go
@@ -27,10 +27,26 @@ func TestForgeReadConfig(t *testing.T) {
 
 	ctx := cli.NewContext(nil, flagSet(t, forgeCommand.Flags), nil)
 
+	// read context from non-existent config file
+	ctx.Set("config", "./testdata/forge_not_exists.toml")
+
+	_, err := readContext(ctx)
+	require.Error(t, err)
+
+	// read context from valid config toml file WITHOUT suave section
+	// it should fallback to the default values
+	ctx.Set("config", "./testdata/forge_noconfig.toml")
+
+	sCtx, err := readContext(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, sCtx.Backend.ExternalWhitelist, 0)
+	require.Len(t, sCtx.Backend.DnsRegistry, 0)
+
 	// read context from config toml file
 	ctx.Set("config", "./testdata/forge.toml")
 
-	sCtx, err := readContext(ctx)
+	sCtx, err = readContext(ctx)
 	require.NoError(t, err)
 	require.Equal(t, sCtx.Backend.ExternalWhitelist, []string{"a", "b"})
 	require.Equal(t, sCtx.Backend.DnsRegistry, map[string]string{"a": "b", "c": "d"})

--- a/cmd/geth/testdata/forge_noconfig.toml
+++ b/cmd/geth/testdata/forge_noconfig.toml
@@ -1,0 +1,3 @@
+[profile.ci.fuzz]
+runs = 10_000
+solc_version = "0.8.23"


### PR DESCRIPTION
## 📝 Summary

If the `foundry.toml` file used to configure the `suave-geth forgecmd` command exists **but** does not have a Suave section, the command panics. This PR fixes that.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
