### PR TITLE
Return valid error from forgecmd calls

### DIFF
--- a/cmd/geth/forgecmd.go
+++ b/cmd/geth/forgecmd.go
@@ -191,7 +191,8 @@ var (
 
 				result, err := vm.NewSuavePrecompiledContractWrapper(common.HexToAddress(addr), suaveCtx).Run(input)
 				if err != nil {
-					return fmt.Errorf("failed to run precompile: %w", err)
+					// the actual error messageis returned in 'result', err only contains the ErrExecutionReverted error
+					return fmt.Errorf(string(result))
 				}
 				fmt.Println(hex.EncodeToString(result))
 			} else {


### PR DESCRIPTION
## 📝 Summary

If a precompile failed during `forgecmd` (i.e. the http endpoint is not whitelisted), `forgecmd` was not returning the error message from the precompile but only "Execution Reverted".

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
