### PR TITLE
Do not error on state change for transient objects

### DIFF
--- a/suave/e2e/workflow_test.go
+++ b/suave/e2e/workflow_test.go
@@ -1168,9 +1168,13 @@ func TestE2EOnChainStateTransition(t *testing.T) {
 	contractAddr := common.Address{0x3}
 	sourceContract := sdk.GetContract(contractAddr, exampleCallSourceContract.Abi, clt)
 
-	// a confidential request cannot make a state change
+	// a confidential request cannot make a state change in the Suapp
 	_, err := sourceContract.SendTransaction("ilegalStateTransition", []interface{}{}, nil)
 	require.Error(t, err)
+
+	// a confidential request can create a new "temporal" contract and change the state there
+	_, err = sourceContract.SendTransaction("offchainCreateNewContract", []interface{}{}, nil)
+	require.NoError(t, err)
 }
 
 func TestE2EConsoleLog(t *testing.T) {

--- a/suave/sol/standard_peekers/example.sol
+++ b/suave/sol/standard_peekers/example.sol
@@ -89,6 +89,20 @@ contract ExampleEthCallSource {
     function offchain() public pure returns (bytes memory) {
         return abi.encodeWithSelector(this.onchain.selector);
     }
+
+    function offchainCreateNewContract() public returns (bytes memory) {
+        Other o = new Other();
+        o.setValue(10);
+        return abi.encodeWithSelector(this.onchain.selector);
+    }
+}
+
+contract Other {
+    uint256 value;
+
+    function setValue(uint256 _value) public {
+        value = _value;
+    }
 }
 
 contract ExampleEthCallTarget {


### PR DESCRIPTION
## 📝 Summary

Since we fail the CCR when a state change happens, this type of patterns is not possible:
```
contract Suapp {
  function example() public {
      Other o = new Other();
  }
}

contract Other {
   string jsonrpc;

   constructor(string _jsonrpc) {
       jsonrpc = _jsonrpc;
   }
}
```

We use this pattern a lot in `suave-std` and it is helpful as a way to describe transient objects with state.

This PR fixes the issue and only fails if the user tries to make state changes for the Suapp itself.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
