### PR TITLE
Add confidential inputs to spell cmd

### DIFF
--- a/cmd/geth/spellcmd/README.md
+++ b/cmd/geth/spellcmd/README.md
@@ -1,0 +1,27 @@
+# Spell command
+
+## Deploy a contract
+
+To deploy a contract, you need to be in the root of a Forge project that contains the built artifacts and run:
+
+```bash
+$ suave-geth spell deploy [--artifacts out] <solidity-file>:<contract-name>
+```
+
+Example:
+
+```bash
+$ suave-geth spell deploy MyContract.sol:MyContract
+```
+
+## Send a confidential compute request
+
+```bash
+$ suave-geth spell conf-request [--confidential-input <input>] <contract-addr> '<function signature>' ['(arg1,arg2)']
+```
+
+Example:
+
+```bash
+$ suave-geth spell conf-request 0x1234567890abcdef1234567890abcdef12345678 'set(uint256)' '(42)'
+```


### PR DESCRIPTION
## 📝 Summary

This PR adds a new flag --confidential-input to the `spell conf-request` command.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
