### PR TITLE
Embed the precompile error in the error message returned in the ccr

### DIFF
--- a/cmd/geth/forgecmd_test.go
+++ b/cmd/geth/forgecmd_test.go
@@ -41,7 +41,7 @@ func TestForgeReadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, sCtx.Backend.ExternalWhitelist, 0)
-	require.Len(t, sCtx.Backend.DnsRegistry, 0)
+	require.Len(t, sCtx.Backend.ServiceAliasRegistry, 0)
 
 	// read context from config toml file
 	ctx.Set("config", "./testdata/forge.toml")

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2123,7 +2123,8 @@ func parseSuavePrecompileError(ret []byte) error {
 
 	size := new(big.Int).SetBytes(ret[64:96]).Uint64()
 	if 96+size > uint64(len(ret)) {
-		panic("BAD")
+		log.Debug("invalid precompile reverted message")
+		return nil
 	}
 
 	msg := ret[96 : 96+size]

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2114,6 +2114,11 @@ func parseSuavePrecompileError(ret []byte) error {
 
 	ret = ret[4:]
 
+	if len(ret) < 96 {
+		log.Debug("invalid precompile reverted message")
+		return nil
+	}
+
 	// In ABI, the PeekerReverted(address, bytes) error is encoded as slots of 32 bytes:
 	// 0-32 bytes: address. 20 bytes padded with zeros to the left.
 	// 32-64 bytes: offset of the dynamic type bytes It is always 0x...040.

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"hash"
@@ -47,6 +48,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	suave "github.com/ethereum/go-ethereum/suave/core"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -740,3 +742,15 @@ func TestRPCMarshalBlock(t *testing.T) {
 		}
 	}
 }
+
+// --- suave specific ---
+
+func TestSuave_ParsePrecompileError(t *testing.T) {
+	txt := "75fff46700000000000000000000000000000000000000000000000000000000432000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000002d47657420227365706f6c6961223a20756e737570706f727465642070726f746f636f6c20736368656d6520222200000000000000000000000000000000000000"
+	txtB, _ := hex.DecodeString(txt)
+
+	err := parseSuavePrecompileError(txtB)
+	require.Equal(t, err.Error(), `precompile '0x0000000000000000000000000000000043200002' reverted: 'Get "sepolia": unsupported protocol scheme ""'`)
+}
+
+// --- end of suave specific ---

--- a/suave/e2e/workflow_test.go
+++ b/suave/e2e/workflow_test.go
@@ -1385,6 +1385,28 @@ func TestE2E_EmptyAddress(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestE2E_PrecompileInternalError(t *testing.T) {
+	// if the precompile fails, return a more informative error
+	fr := newFramework(t)
+	defer fr.Close()
+
+	clt := fr.NewSDKClient()
+
+	contractAddr := common.Address{0x3}
+	contract := sdk.GetContract(contractAddr, exampleCallSourceContract.Abi, clt)
+
+	req := &types.HttpRequest{
+		Method: "GET",
+		Url:    "sepolia",
+	}
+	_, err := contract.SendTransaction("remoteCall", []interface{}{req}, nil)
+	require.Error(t, err)
+
+	if !strings.Contains(err.Error(), `precompile '0x0000000000000000000000000000000043200002' reverted`) {
+		t.Fatal("bad")
+	}
+}
+
 type clientWrapper struct {
 	t *testing.T
 


### PR DESCRIPTION
## 📝 Summary

This PR embeds the error from the precompile (if it failed because of a precompile) in the return message from the call to send the CCR.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
