### PR TITLE
Convert conf inputs to bytes if hex input

### DIFF
--- a/cmd/geth/spellcmd/spellcmd.go
+++ b/cmd/geth/spellcmd/spellcmd.go
@@ -143,7 +143,13 @@ var (
 
 			var confInput []byte
 			if input := ctx.String(confidentialInput.Name); input != "" {
-				confInput = []byte(input)
+				if strings.HasPrefix(input, "0x") {
+					if confInput, err = hexutil.Decode(input); err != nil {
+						return fmt.Errorf("failed to decode hex confidential input: %w", err)
+					}
+				} else {
+					confInput = []byte(input)
+				}
 				log.Info("Confidential input provided", "input", confInput)
 			} else {
 				log.Info("No confidential input provided, using empty string")


### PR DESCRIPTION
## 📝 Summary

This PR fixes a bug in the spell command where the confidential inputs were not being parsed as hex input.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
