### PR TITLE
Sign CCRs as EIP-712 messages

### DIFF
--- a/core/types/confidential.go
+++ b/core/types/confidential.go
@@ -18,7 +18,7 @@ type ConfidentialComputeRecord struct {
 	ConfidentialInputsHash common.Hash
 
 	// Envelope signals whether this CCR was signed using EIP-712
-	Envelope bool
+	IsEIP712 bool
 
 	ChainID *big.Int
 	V, R, S *big.Int
@@ -33,7 +33,7 @@ func (tx *ConfidentialComputeRecord) copy() TxData {
 		Gas:                    tx.Gas,
 		KettleAddress:          tx.KettleAddress,
 		ConfidentialInputsHash: tx.ConfidentialInputsHash,
-		Envelope:               tx.Envelope,
+		IsEIP712:               tx.IsEIP712,
 
 		Value:    new(big.Int),
 		GasPrice: new(big.Int),

--- a/core/types/confidential.go
+++ b/core/types/confidential.go
@@ -17,6 +17,9 @@ type ConfidentialComputeRecord struct {
 	KettleAddress          common.Address
 	ConfidentialInputsHash common.Hash
 
+	// Envelope signals whether this CCR was signed using EIP-712
+	Envelope bool
+
 	ChainID *big.Int
 	V, R, S *big.Int
 }
@@ -30,6 +33,7 @@ func (tx *ConfidentialComputeRecord) copy() TxData {
 		Gas:                    tx.Gas,
 		KettleAddress:          tx.KettleAddress,
 		ConfidentialInputsHash: tx.ConfidentialInputsHash,
+		Envelope:               tx.Envelope,
 
 		Value:    new(big.Int),
 		GasPrice: new(big.Int),

--- a/core/types/suave_eip712.go
+++ b/core/types/suave_eip712.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/signer/core/eip712"
 )
 
@@ -20,7 +19,7 @@ func CCREIP712Envelope(msg *ConfidentialComputeRecord) eip712.TypedData {
 		Types: eip712.Types{
 			"EIP712Domain": []eip712.Type{
 				{Name: "name", Type: "string"},
-				{Name: "chainId", Type: "uint256"},
+				{Name: "verifyingContract", Type: "address"},
 			},
 			"ConfidentialRecord": []eip712.Type{
 				{Name: "nonce", Type: "uint64"},
@@ -34,8 +33,8 @@ func CCREIP712Envelope(msg *ConfidentialComputeRecord) eip712.TypedData {
 			},
 		},
 		Domain: eip712.TypedDataDomain{
-			Name:    "ConfidentialRecord",
-			ChainId: math.NewHexOrDecimal256(msg.ChainID.Int64()),
+			Name:              "ConfidentialRecord",
+			VerifyingContract: msg.KettleAddress.Hex(),
 		},
 		PrimaryType: "ConfidentialRecord",
 		Message: eip712.TypedDataMessage{

--- a/core/types/suave_eip712.go
+++ b/core/types/suave_eip712.go
@@ -1,0 +1,52 @@
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/signer/core/eip712"
+)
+
+func (msg *ConfidentialComputeRecord) EIP712Hash() (common.Hash, error) {
+	hash, _, err := eip712.TypedDataAndHash(CCREIP712Envelope(msg))
+
+	hash32 := common.Hash{}
+	copy(hash32[:], hash[:])
+
+	return hash32, err
+}
+
+func CCREIP712Envelope(msg *ConfidentialComputeRecord) eip712.TypedData {
+	return eip712.TypedData{
+		Types: eip712.Types{
+			"EIP712Domain": []eip712.Type{
+				{Name: "name", Type: "string"},
+				{Name: "chainId", Type: "uint256"},
+			},
+			"ConfidentialRecord": []eip712.Type{
+				{Name: "nonce", Type: "uint64"},
+				{Name: "gasPrice", Type: "uint256"},
+				{Name: "gas", Type: "uint64"},
+				{Name: "to", Type: "address"},
+				{Name: "value", Type: "uint256"},
+				{Name: "data", Type: "bytes"},
+				{Name: "kettleAddress", Type: "address"},
+				{Name: "confidentialInputsHash", Type: "bytes32"},
+			},
+		},
+		Domain: eip712.TypedDataDomain{
+			Name:    "ConfidentialRecord",
+			ChainId: math.NewHexOrDecimal256(msg.ChainID.Int64()),
+		},
+		PrimaryType: "ConfidentialRecord",
+		Message: eip712.TypedDataMessage{
+			"nonce":                  msg.Nonce,
+			"gasPrice":               msg.GasPrice,
+			"gas":                    msg.Gas,
+			"to":                     msg.To,
+			"value":                  msg.Value,
+			"data":                   msg.Data,
+			"kettleAddress":          msg.KettleAddress,
+			"confidentialInputsHash": msg.ConfidentialInputsHash,
+		},
+	}
+}

--- a/core/types/suave_eip712_test.go
+++ b/core/types/suave_eip712_test.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCCREIP712(t *testing.T) {
+	to := common.Address{0x2}
+
+	ccr := &ConfidentialComputeRecord{
+		GasPrice: big.NewInt(0),
+		To:       &to,
+		Value:    big.NewInt(0),
+		ChainID:  big.NewInt(0),
+	}
+
+	_, err := ccr.EIP712Hash()
+	require.NoError(t, err)
+}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -44,7 +44,7 @@ type txJSON struct {
 	BlobVersionedHashes       []common.Hash    `json:"blobVersionedHashes,omitempty"`
 	KettleAddress             *common.Address  `json:"kettleAddress,omitempty"`
 	ConfidentialInputsHash    *common.Hash     `json:"confidentialInputsHash,omitempty"`
-	Envelope                  *bool            `json:"envelope,omitempty"`
+	IsEIP712                  *bool            `json:"iseip712,omitempty"`
 	ConfidentialInputs        *hexutil.Bytes   `json:"confidentialInputs,omitempty"`
 	RequestRecord             *json.RawMessage `json:"requestRecord,omitempty"`
 	ConfidentialComputeResult *hexutil.Bytes   `json:"confidentialComputeResult,omitempty"`
@@ -147,7 +147,7 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.V = (*hexutil.Big)(itx.V)
 		enc.R = (*hexutil.Big)(itx.R)
 		enc.S = (*hexutil.Big)(itx.S)
-		enc.Envelope = &itx.Envelope
+		enc.IsEIP712 = &itx.IsEIP712
 
 	case *SuaveTransaction:
 		requestRecord, err := NewTx(&itx.ConfidentialComputeRequest).MarshalJSON()
@@ -500,8 +500,8 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'chainId' in transaction")
 		}
 		itx.ChainID = (*big.Int)(dec.ChainID)
-		if dec.Envelope != nil {
-			itx.Envelope = *dec.Envelope
+		if dec.IsEIP712 != nil {
+			itx.IsEIP712 = *dec.IsEIP712
 		}
 		if dec.V == nil {
 			return errors.New("missing required field 'r' in transaction")

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -44,6 +44,7 @@ type txJSON struct {
 	BlobVersionedHashes       []common.Hash    `json:"blobVersionedHashes,omitempty"`
 	KettleAddress             *common.Address  `json:"kettleAddress,omitempty"`
 	ConfidentialInputsHash    *common.Hash     `json:"confidentialInputsHash,omitempty"`
+	Envelope                  *bool            `json:"envelope,omitempty"`
 	ConfidentialInputs        *hexutil.Bytes   `json:"confidentialInputs,omitempty"`
 	RequestRecord             *json.RawMessage `json:"requestRecord,omitempty"`
 	ConfidentialComputeResult *hexutil.Bytes   `json:"confidentialComputeResult,omitempty"`
@@ -146,6 +147,7 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.V = (*hexutil.Big)(itx.V)
 		enc.R = (*hexutil.Big)(itx.R)
 		enc.S = (*hexutil.Big)(itx.S)
+		enc.Envelope = &itx.Envelope
 
 	case *SuaveTransaction:
 		requestRecord, err := NewTx(&itx.ConfidentialComputeRequest).MarshalJSON()
@@ -498,6 +500,9 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'chainId' in transaction")
 		}
 		itx.ChainID = (*big.Int)(dec.ChainID)
+		if dec.Envelope != nil {
+			itx.Envelope = *dec.Envelope
+		}
 		if dec.V == nil {
 			return errors.New("missing required field 'r' in transaction")
 		}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -358,6 +359,15 @@ func (s suaveSigner) Hash(tx *Transaction) common.Hash {
 				txdata.ConfidentialComputeResult,
 			})
 	case *ConfidentialComputeRequest:
+		if txdata.Envelope {
+			// EIP-712 signature used during signing
+			hash, err := txdata.ConfidentialComputeRecord.EIP712Hash()
+			if err != nil {
+				log.Error("failed to calculate EIP712 hash", "err", err)
+			}
+			return hash
+		}
+
 		return prefixedRlpHash(
 			ConfidentialComputeRecordTxType, // Note: this is the same as the Record so that hashes match!
 			[]interface{}{
@@ -371,6 +381,16 @@ func (s suaveSigner) Hash(tx *Transaction) common.Hash {
 				tx.Data(),
 			})
 	case *ConfidentialComputeRecord:
+		if txdata.Envelope {
+			// EIP-712 signature using during recovery
+			hash, err := txdata.EIP712Hash()
+			if err != nil {
+				log.Error("failed to calculate EIP712 hash", "err", err)
+			}
+			return hash
+		}
+
+		// normal txn signature
 		return prefixedRlpHash(
 			tx.Type(),
 			[]interface{}{
@@ -687,6 +707,10 @@ func (fs FrontierSigner) Hash(tx *Transaction) common.Hash {
 		tx.Value(),
 		tx.Data(),
 	})
+}
+
+func DecodeSignature(sig []byte) (r, s, v *big.Int) {
+	return decodeSignature(sig)
 }
 
 func decodeSignature(sig []byte) (r, s, v *big.Int) {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -359,7 +359,7 @@ func (s suaveSigner) Hash(tx *Transaction) common.Hash {
 				txdata.ConfidentialComputeResult,
 			})
 	case *ConfidentialComputeRequest:
-		if txdata.Envelope {
+		if txdata.IsEIP712 {
 			// EIP-712 signature used during signing
 			hash, err := txdata.ConfidentialComputeRecord.EIP712Hash()
 			if err != nil {
@@ -381,7 +381,7 @@ func (s suaveSigner) Hash(tx *Transaction) common.Hash {
 				tx.Data(),
 			})
 	case *ConfidentialComputeRecord:
-		if txdata.Envelope {
+		if txdata.IsEIP712 {
 			// EIP-712 signature using during recovery
 			hash, err := txdata.EIP712Hash()
 			if err != nil {

--- a/signer/core/eip712/signed_data_internal_test.go
+++ b/signer/core/eip712/signed_data_internal_test.go
@@ -1,0 +1,235 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eip712
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+)
+
+func TestBytesPadding(t *testing.T) {
+	tests := []struct {
+		Type   string
+		Input  []byte
+		Output []byte // nil => error
+	}{
+		{
+			// Fail on wrong length
+			Type:   "bytes20",
+			Input:  []byte{},
+			Output: nil,
+		},
+		{
+			Type:   "bytes1",
+			Input:  []byte{1},
+			Output: []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Type:   "bytes1",
+			Input:  []byte{1, 2},
+			Output: nil,
+		},
+		{
+			Type:   "bytes7",
+			Input:  []byte{1, 2, 3, 4, 5, 6, 7},
+			Output: []byte{1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Type:   "bytes32",
+			Input:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+			Output: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+		},
+		{
+			Type:   "bytes32",
+			Input:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
+			Output: nil,
+		},
+	}
+
+	d := TypedData{}
+	for i, test := range tests {
+		val, err := d.EncodePrimitiveValue(test.Type, test.Input, 1)
+		if test.Output == nil {
+			if err == nil {
+				t.Errorf("test %d: expected error, got no error (result %x)", i, val)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("test %d: expected no error, got %v", i, err)
+			}
+			if len(val) != 32 {
+				t.Errorf("test %d: expected len 32, got %d", i, len(val))
+			}
+			if !bytes.Equal(val, test.Output) {
+				t.Errorf("test %d: expected %x, got %x", i, test.Output, val)
+			}
+		}
+	}
+}
+
+func TestParseAddress(t *testing.T) {
+	tests := []struct {
+		Input  interface{}
+		Output []byte // nil => error
+	}{
+		{
+			Input:  [20]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14},
+			Output: common.FromHex("0x0000000000000000000000000102030405060708090A0B0C0D0E0F1011121314"),
+		},
+		{
+			Input:  "0x0102030405060708090A0B0C0D0E0F1011121314",
+			Output: common.FromHex("0x0000000000000000000000000102030405060708090A0B0C0D0E0F1011121314"),
+		},
+		{
+			Input:  []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14},
+			Output: common.FromHex("0x0000000000000000000000000102030405060708090A0B0C0D0E0F1011121314"),
+		},
+		// Various error-cases:
+		{Input: "0x000102030405060708090A0B0C0D0E0F1011121314"}, // too long string
+		{Input: "0x01"}, // too short string
+		{Input: ""},
+		{Input: [32]byte{}},       // too long fixed-size array
+		{Input: [21]byte{}},       // too long fixed-size array
+		{Input: make([]byte, 19)}, // too short slice
+		{Input: make([]byte, 21)}, // too long slice
+		{Input: nil},
+	}
+
+	d := TypedData{}
+	for i, test := range tests {
+		val, err := d.EncodePrimitiveValue("address", test.Input, 1)
+		if test.Output == nil {
+			if err == nil {
+				t.Errorf("test %d: expected error, got no error (result %x)", i, val)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("test %d: expected no error, got %v", i, err)
+		}
+		if have, want := len(val), 32; have != want {
+			t.Errorf("test %d: have len %d, want %d", i, have, want)
+		}
+		if !bytes.Equal(val, test.Output) {
+			t.Errorf("test %d: want %x, have %x", i, test.Output, val)
+		}
+	}
+}
+
+func TestParseBytes(t *testing.T) {
+	for i, tt := range []struct {
+		v   interface{}
+		exp []byte
+	}{
+		{"0x", []byte{}},
+		{"0x1234", []byte{0x12, 0x34}},
+		{[]byte{12, 34}, []byte{12, 34}},
+		{hexutil.Bytes([]byte{12, 34}), []byte{12, 34}},
+		{"1234", nil},    // not a proper hex-string
+		{"0x01233", nil}, // nibbles should be rejected
+		{"not a hex string", nil},
+		{15, nil},
+		{nil, nil},
+		{[2]byte{12, 34}, []byte{12, 34}},
+		{[8]byte{12, 34, 56, 78, 90, 12, 34, 56}, []byte{12, 34, 56, 78, 90, 12, 34, 56}},
+		{[16]byte{12, 34, 56, 78, 90, 12, 34, 56, 12, 34, 56, 78, 90, 12, 34, 56}, []byte{12, 34, 56, 78, 90, 12, 34, 56, 12, 34, 56, 78, 90, 12, 34, 56}},
+	} {
+		out, ok := parseBytes(tt.v)
+		if tt.exp == nil {
+			if ok || out != nil {
+				t.Errorf("test %d: expected !ok, got ok = %v with out = %x", i, ok, out)
+			}
+			continue
+		}
+		if !ok {
+			t.Errorf("test %d: expected ok got !ok", i)
+		}
+		if !bytes.Equal(out, tt.exp) {
+			t.Errorf("test %d: expected %x got %x", i, tt.exp, out)
+		}
+	}
+}
+
+func TestParseInteger(t *testing.T) {
+	for i, tt := range []struct {
+		t   string
+		v   interface{}
+		exp *big.Int
+	}{
+		{"uint32", "-123", nil},
+		{"int32", "-123", big.NewInt(-123)},
+		{"int32", big.NewInt(-124), big.NewInt(-124)},
+		{"uint32", "0xff", big.NewInt(0xff)},
+		{"int8", "0xffff", nil},
+	} {
+		res, err := parseInteger(tt.t, tt.v)
+		if tt.exp == nil && res == nil {
+			continue
+		}
+		if tt.exp == nil && res != nil {
+			t.Errorf("test %d, got %v, expected nil", i, res)
+			continue
+		}
+		if tt.exp != nil && res == nil {
+			t.Errorf("test %d, got '%v', expected %v", i, err, tt.exp)
+			continue
+		}
+		if tt.exp.Cmp(res) != 0 {
+			t.Errorf("test %d, got %v expected %v", i, res, tt.exp)
+		}
+	}
+}
+
+func TestConvertStringDataToSlice(t *testing.T) {
+	slice := []string{"a", "b", "c"}
+	var it interface{} = slice
+	_, err := convertDataToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConvertUint256DataToSlice(t *testing.T) {
+	slice := []*math.HexOrDecimal256{
+		math.NewHexOrDecimal256(1),
+		math.NewHexOrDecimal256(2),
+		math.NewHexOrDecimal256(3),
+	}
+	var it interface{} = slice
+	_, err := convertDataToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConvertAddressDataToSlice(t *testing.T) {
+	slice := []common.Address{
+		common.HexToAddress("0x0000000000000000000000000000000000000001"),
+		common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		common.HexToAddress("0x0000000000000000000000000000000000000003"),
+	}
+	var it interface{} = slice
+	_, err := convertDataToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/signer/core/eip712/types.go
+++ b/signer/core/eip712/types.go
@@ -1,0 +1,732 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eip712
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var typedDataReferenceTypeRegexp = regexp.MustCompile(`^[A-Za-z](\w*)(\[\])?$`)
+
+type ValidationInfo struct {
+	Typ     string `json:"type"`
+	Message string `json:"message"`
+}
+type ValidationMessages struct {
+	Messages []ValidationInfo
+}
+
+const (
+	WARN = "WARNING"
+	CRIT = "CRITICAL"
+	INFO = "Info"
+)
+
+func (vs *ValidationMessages) Crit(msg string) {
+	vs.Messages = append(vs.Messages, ValidationInfo{CRIT, msg})
+}
+func (vs *ValidationMessages) Warn(msg string) {
+	vs.Messages = append(vs.Messages, ValidationInfo{WARN, msg})
+}
+func (vs *ValidationMessages) Info(msg string) {
+	vs.Messages = append(vs.Messages, ValidationInfo{INFO, msg})
+}
+
+// getWarnings returns an error with all messages of type WARN of above, or nil if no warnings were present
+func (v *ValidationMessages) GetWarnings() error {
+	var messages []string
+	for _, msg := range v.Messages {
+		if msg.Typ == WARN || msg.Typ == CRIT {
+			messages = append(messages, msg.Message)
+		}
+	}
+	if len(messages) > 0 {
+		return fmt.Errorf("validation failed: %s", strings.Join(messages, ","))
+	}
+	return nil
+}
+
+type SigFormat struct {
+	Mime        string
+	ByteVersion byte
+}
+
+type ValidatorData struct {
+	Address common.Address
+	Message hexutil.Bytes
+}
+
+// TypedData is a type to encapsulate EIP-712 typed messages
+type TypedData struct {
+	Types       Types            `json:"types"`
+	PrimaryType string           `json:"primaryType"`
+	Domain      TypedDataDomain  `json:"domain"`
+	Message     TypedDataMessage `json:"message"`
+}
+
+// Type is the inner type of an EIP-712 message
+type Type struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+func (t *Type) isArray() bool {
+	return strings.HasSuffix(t.Type, "[]")
+}
+
+// typeName returns the canonical name of the type. If the type is 'Person[]', then
+// this method returns 'Person'
+func (t *Type) typeName() string {
+	if strings.HasSuffix(t.Type, "[]") {
+		return strings.TrimSuffix(t.Type, "[]")
+	}
+	return t.Type
+}
+
+type Types map[string][]Type
+
+type TypePriority struct {
+	Type  string
+	Value uint
+}
+
+type TypedDataMessage = map[string]interface{}
+
+// TypedDataDomain represents the domain part of an EIP-712 message.
+type TypedDataDomain struct {
+	Name              string                `json:"name"`
+	Version           string                `json:"version"`
+	ChainId           *math.HexOrDecimal256 `json:"chainId"`
+	VerifyingContract string                `json:"verifyingContract"`
+	Salt              string                `json:"salt"`
+}
+
+// TypedDataAndHash is a helper function that calculates a hash for typed data conforming to EIP-712.
+// This hash can then be safely used to calculate a signature.
+//
+// See https://eips.ethereum.org/EIPS/eip-712 for the full specification.
+//
+// This gives context to the signed typed data and prevents signing of transactions.
+func TypedDataAndHash(typedData TypedData) ([]byte, string, error) {
+	domainSeparator, err := typedData.HashStruct("EIP712Domain", typedData.Domain.Map())
+	if err != nil {
+		return nil, "", err
+	}
+	typedDataHash, err := typedData.HashStruct(typedData.PrimaryType, typedData.Message)
+	if err != nil {
+		return nil, "", err
+	}
+	rawData := fmt.Sprintf("\x19\x01%s%s", string(domainSeparator), string(typedDataHash))
+	return crypto.Keccak256([]byte(rawData)), rawData, nil
+}
+
+// HashStruct generates a keccak256 hash of the encoding of the provided data
+func (typedData *TypedData) HashStruct(primaryType string, data TypedDataMessage) (hexutil.Bytes, error) {
+	encodedData, err := typedData.EncodeData(primaryType, data, 1)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.Keccak256(encodedData), nil
+}
+
+// Dependencies returns an array of custom types ordered by their hierarchical reference tree
+func (typedData *TypedData) Dependencies(primaryType string, found []string) []string {
+	primaryType = strings.TrimSuffix(primaryType, "[]")
+	includes := func(arr []string, str string) bool {
+		for _, obj := range arr {
+			if obj == str {
+				return true
+			}
+		}
+		return false
+	}
+
+	if includes(found, primaryType) {
+		return found
+	}
+	if typedData.Types[primaryType] == nil {
+		return found
+	}
+	found = append(found, primaryType)
+	for _, field := range typedData.Types[primaryType] {
+		for _, dep := range typedData.Dependencies(field.Type, found) {
+			if !includes(found, dep) {
+				found = append(found, dep)
+			}
+		}
+	}
+	return found
+}
+
+// EncodeType generates the following encoding:
+// `name ‖ "(" ‖ member₁ ‖ "," ‖ member₂ ‖ "," ‖ … ‖ memberₙ ")"`
+//
+// each member is written as `type ‖ " " ‖ name` encodings cascade down and are sorted by name
+func (typedData *TypedData) EncodeType(primaryType string) hexutil.Bytes {
+	// Get dependencies primary first, then alphabetical
+	deps := typedData.Dependencies(primaryType, []string{})
+	if len(deps) > 0 {
+		slicedDeps := deps[1:]
+		sort.Strings(slicedDeps)
+		deps = append([]string{primaryType}, slicedDeps...)
+	}
+
+	// Format as a string with fields
+	var buffer bytes.Buffer
+	for _, dep := range deps {
+		buffer.WriteString(dep)
+		buffer.WriteString("(")
+		for _, obj := range typedData.Types[dep] {
+			buffer.WriteString(obj.Type)
+			buffer.WriteString(" ")
+			buffer.WriteString(obj.Name)
+			buffer.WriteString(",")
+		}
+		buffer.Truncate(buffer.Len() - 1)
+		buffer.WriteString(")")
+	}
+	return buffer.Bytes()
+}
+
+// TypeHash creates the keccak256 hash  of the data
+func (typedData *TypedData) TypeHash(primaryType string) hexutil.Bytes {
+	return crypto.Keccak256(typedData.EncodeType(primaryType))
+}
+
+// EncodeData generates the following encoding:
+// `enc(value₁) ‖ enc(value₂) ‖ … ‖ enc(valueₙ)`
+//
+// each encoded member is 32-byte long
+func (typedData *TypedData) EncodeData(primaryType string, data map[string]interface{}, depth int) (hexutil.Bytes, error) {
+	if err := typedData.validate(); err != nil {
+		return nil, err
+	}
+
+	buffer := bytes.Buffer{}
+
+	// Verify extra data
+	if exp, got := len(typedData.Types[primaryType]), len(data); exp < got {
+		return nil, fmt.Errorf("there is extra data provided in the message (%d < %d)", exp, got)
+	}
+
+	// Add typehash
+	buffer.Write(typedData.TypeHash(primaryType))
+
+	// Add field contents. Structs and arrays have special handlers.
+	for _, field := range typedData.Types[primaryType] {
+		encType := field.Type
+		encValue := data[field.Name]
+		if encType[len(encType)-1:] == "]" {
+			arrayValue, err := convertDataToSlice(encValue)
+			if err != nil {
+				return nil, dataMismatchError(encType, encValue)
+			}
+
+			arrayBuffer := bytes.Buffer{}
+			parsedType := strings.Split(encType, "[")[0]
+			for _, item := range arrayValue {
+				if typedData.Types[parsedType] != nil {
+					mapValue, ok := item.(map[string]interface{})
+					if !ok {
+						return nil, dataMismatchError(parsedType, item)
+					}
+					encodedData, err := typedData.EncodeData(parsedType, mapValue, depth+1)
+					if err != nil {
+						return nil, err
+					}
+					arrayBuffer.Write(crypto.Keccak256(encodedData))
+				} else {
+					bytesValue, err := typedData.EncodePrimitiveValue(parsedType, item, depth)
+					if err != nil {
+						return nil, err
+					}
+					arrayBuffer.Write(bytesValue)
+				}
+			}
+
+			buffer.Write(crypto.Keccak256(arrayBuffer.Bytes()))
+		} else if typedData.Types[field.Type] != nil {
+			mapValue, ok := encValue.(map[string]interface{})
+			if !ok {
+				return nil, dataMismatchError(encType, encValue)
+			}
+			encodedData, err := typedData.EncodeData(field.Type, mapValue, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			buffer.Write(crypto.Keccak256(encodedData))
+		} else {
+			byteValue, err := typedData.EncodePrimitiveValue(encType, encValue, depth)
+			if err != nil {
+				return nil, err
+			}
+			buffer.Write(byteValue)
+		}
+	}
+	return buffer.Bytes(), nil
+}
+
+// Attempt to parse bytes in different formats: byte array, hex string, hexutil.Bytes.
+func parseBytes(encType interface{}) ([]byte, bool) {
+	// Handle array types.
+	val := reflect.ValueOf(encType)
+	if val.Kind() == reflect.Array && val.Type().Elem().Kind() == reflect.Uint8 {
+		v := reflect.MakeSlice(reflect.TypeOf([]byte{}), val.Len(), val.Len())
+		reflect.Copy(v, val)
+		return v.Bytes(), true
+	}
+
+	switch v := encType.(type) {
+	case []byte:
+		return v, true
+	case hexutil.Bytes:
+		return v, true
+	case string:
+		bytes, err := hexutil.Decode(v)
+		if err != nil {
+			return nil, false
+		}
+		return bytes, true
+	default:
+		return nil, false
+	}
+}
+
+func parseInteger(encType string, encValue interface{}) (*big.Int, error) {
+	var (
+		length int
+		signed = strings.HasPrefix(encType, "int")
+		b      *big.Int
+	)
+	if encType == "int" || encType == "uint" {
+		length = 256
+	} else {
+		lengthStr := ""
+		if strings.HasPrefix(encType, "uint") {
+			lengthStr = strings.TrimPrefix(encType, "uint")
+		} else {
+			lengthStr = strings.TrimPrefix(encType, "int")
+		}
+		atoiSize, err := strconv.Atoi(lengthStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid size on integer: %v", lengthStr)
+		}
+		length = atoiSize
+	}
+	switch v := encValue.(type) {
+	case *math.HexOrDecimal256:
+		b = (*big.Int)(v)
+	case *big.Int:
+		b = v
+	case string:
+		var hexIntValue math.HexOrDecimal256
+		if err := hexIntValue.UnmarshalText([]byte(v)); err != nil {
+			return nil, err
+		}
+		b = (*big.Int)(&hexIntValue)
+	case float64:
+		// JSON parses non-strings as float64. Fail if we cannot
+		// convert it losslessly
+		if float64(int64(v)) == v {
+			b = big.NewInt(int64(v))
+		} else {
+			return nil, fmt.Errorf("invalid float value %v for type %v", v, encType)
+		}
+	case uint64:
+		b = new(big.Int).SetUint64(v)
+	}
+	if b == nil {
+		return nil, fmt.Errorf("invalid integer value %v/%v for type %v", encValue, reflect.TypeOf(encValue), encType)
+	}
+	if b.BitLen() > length {
+		return nil, fmt.Errorf("integer larger than '%v'", encType)
+	}
+	if !signed && b.Sign() == -1 {
+		return nil, fmt.Errorf("invalid negative value for unsigned type %v", encType)
+	}
+	return b, nil
+}
+
+// EncodePrimitiveValue deals with the primitive values found
+// while searching through the typed data
+func (typedData *TypedData) EncodePrimitiveValue(encType string, encValue interface{}, depth int) ([]byte, error) {
+	switch encType {
+	case "address":
+		retval := make([]byte, 32)
+		switch val := encValue.(type) {
+		case string:
+			if common.IsHexAddress(val) {
+				copy(retval[12:], common.HexToAddress(val).Bytes())
+				return retval, nil
+			}
+		case []byte:
+			if len(val) == 20 {
+				copy(retval[12:], val)
+				return retval, nil
+			}
+		case *common.Address:
+			copy(retval[12:], val.Bytes())
+			return retval, nil
+		case common.Address:
+			copy(retval[12:], val.Bytes())
+			return retval, nil
+		case [20]byte:
+			copy(retval[12:], val[:])
+			return retval, nil
+		}
+		return nil, dataMismatchError(encType, encValue)
+	case "bool":
+		boolValue, ok := encValue.(bool)
+		if !ok {
+			return nil, dataMismatchError(encType, encValue)
+		}
+		if boolValue {
+			return math.PaddedBigBytes(common.Big1, 32), nil
+		}
+		return math.PaddedBigBytes(common.Big0, 32), nil
+	case "string":
+		strVal, ok := encValue.(string)
+		if !ok {
+			return nil, dataMismatchError(encType, encValue)
+		}
+		return crypto.Keccak256([]byte(strVal)), nil
+	case "bytes":
+		bytesValue, ok := parseBytes(encValue)
+		if !ok {
+			return nil, dataMismatchError(encType, encValue)
+		}
+		return crypto.Keccak256(bytesValue), nil
+	}
+	if strings.HasPrefix(encType, "bytes") {
+		lengthStr := strings.TrimPrefix(encType, "bytes")
+		length, err := strconv.Atoi(lengthStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid size on bytes: %v", lengthStr)
+		}
+		if length < 0 || length > 32 {
+			return nil, fmt.Errorf("invalid size on bytes: %d", length)
+		}
+		if byteValue, ok := parseBytes(encValue); !ok || len(byteValue) != length {
+			return nil, dataMismatchError(encType, encValue)
+		} else {
+			// Right-pad the bits
+			dst := make([]byte, 32)
+			copy(dst, byteValue)
+			return dst, nil
+		}
+	}
+	if strings.HasPrefix(encType, "int") || strings.HasPrefix(encType, "uint") {
+		b, err := parseInteger(encType, encValue)
+		if err != nil {
+			return nil, err
+		}
+		return math.U256Bytes(b), nil
+	}
+	return nil, fmt.Errorf("unrecognized type '%s'", encType)
+}
+
+// dataMismatchError generates an error for a mismatch between
+// the provided type and data
+func dataMismatchError(encType string, encValue interface{}) error {
+	return fmt.Errorf("provided data '%v' doesn't match type '%s'", encValue, encType)
+}
+
+func convertDataToSlice(encValue interface{}) ([]interface{}, error) {
+	var outEncValue []interface{}
+	rv := reflect.ValueOf(encValue)
+	if rv.Kind() == reflect.Slice {
+		for i := 0; i < rv.Len(); i++ {
+			outEncValue = append(outEncValue, rv.Index(i).Interface())
+		}
+	} else {
+		return outEncValue, fmt.Errorf("provided data '%v' is not slice", encValue)
+	}
+	return outEncValue, nil
+}
+
+// validate makes sure the types are sound
+func (typedData *TypedData) validate() error {
+	if err := typedData.Types.validate(); err != nil {
+		return err
+	}
+	if err := typedData.Domain.validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Map generates a map version of the typed data
+func (typedData *TypedData) Map() map[string]interface{} {
+	dataMap := map[string]interface{}{
+		"types":       typedData.Types,
+		"domain":      typedData.Domain.Map(),
+		"primaryType": typedData.PrimaryType,
+		"message":     typedData.Message,
+	}
+	return dataMap
+}
+
+// Format returns a representation of typedData, which can be easily displayed by a user-interface
+// without in-depth knowledge about 712 rules
+func (typedData *TypedData) Format() ([]*NameValueType, error) {
+	domain, err := typedData.formatData("EIP712Domain", typedData.Domain.Map())
+	if err != nil {
+		return nil, err
+	}
+	ptype, err := typedData.formatData(typedData.PrimaryType, typedData.Message)
+	if err != nil {
+		return nil, err
+	}
+	var nvts []*NameValueType
+	nvts = append(nvts, &NameValueType{
+		Name:  "EIP712Domain",
+		Value: domain,
+		Typ:   "domain",
+	})
+	nvts = append(nvts, &NameValueType{
+		Name:  typedData.PrimaryType,
+		Value: ptype,
+		Typ:   "primary type",
+	})
+	return nvts, nil
+}
+
+func (typedData *TypedData) formatData(primaryType string, data map[string]interface{}) ([]*NameValueType, error) {
+	var output []*NameValueType
+
+	// Add field contents. Structs and arrays have special handlers.
+	for _, field := range typedData.Types[primaryType] {
+		encName := field.Name
+		encValue := data[encName]
+		item := &NameValueType{
+			Name: encName,
+			Typ:  field.Type,
+		}
+		if field.isArray() {
+			arrayValue, _ := convertDataToSlice(encValue)
+			parsedType := field.typeName()
+			for _, v := range arrayValue {
+				if typedData.Types[parsedType] != nil {
+					mapValue, _ := v.(map[string]interface{})
+					mapOutput, err := typedData.formatData(parsedType, mapValue)
+					if err != nil {
+						return nil, err
+					}
+					item.Value = mapOutput
+				} else {
+					primitiveOutput, err := formatPrimitiveValue(field.Type, encValue)
+					if err != nil {
+						return nil, err
+					}
+					item.Value = primitiveOutput
+				}
+			}
+		} else if typedData.Types[field.Type] != nil {
+			if mapValue, ok := encValue.(map[string]interface{}); ok {
+				mapOutput, err := typedData.formatData(field.Type, mapValue)
+				if err != nil {
+					return nil, err
+				}
+				item.Value = mapOutput
+			} else {
+				item.Value = "<nil>"
+			}
+		} else {
+			primitiveOutput, err := formatPrimitiveValue(field.Type, encValue)
+			if err != nil {
+				return nil, err
+			}
+			item.Value = primitiveOutput
+		}
+		output = append(output, item)
+	}
+	return output, nil
+}
+
+func formatPrimitiveValue(encType string, encValue interface{}) (string, error) {
+	switch encType {
+	case "address":
+		if stringValue, ok := encValue.(string); !ok {
+			return "", fmt.Errorf("could not format value %v as address", encValue)
+		} else {
+			return common.HexToAddress(stringValue).String(), nil
+		}
+	case "bool":
+		if boolValue, ok := encValue.(bool); !ok {
+			return "", fmt.Errorf("could not format value %v as bool", encValue)
+		} else {
+			return fmt.Sprintf("%t", boolValue), nil
+		}
+	case "bytes", "string":
+		return fmt.Sprintf("%s", encValue), nil
+	}
+	if strings.HasPrefix(encType, "bytes") {
+		return fmt.Sprintf("%s", encValue), nil
+	}
+	if strings.HasPrefix(encType, "uint") || strings.HasPrefix(encType, "int") {
+		if b, err := parseInteger(encType, encValue); err != nil {
+			return "", err
+		} else {
+			return fmt.Sprintf("%d (%#x)", b, b), nil
+		}
+	}
+	return "", fmt.Errorf("unhandled type %v", encType)
+}
+
+// Validate checks if the types object is conformant to the specs
+func (t Types) validate() error {
+	for typeKey, typeArr := range t {
+		if len(typeKey) == 0 {
+			return fmt.Errorf("empty type key")
+		}
+		for i, typeObj := range typeArr {
+			if len(typeObj.Type) == 0 {
+				return fmt.Errorf("type %q:%d: empty Type", typeKey, i)
+			}
+			if len(typeObj.Name) == 0 {
+				return fmt.Errorf("type %q:%d: empty Name", typeKey, i)
+			}
+			if typeKey == typeObj.Type {
+				return fmt.Errorf("type %q cannot reference itself", typeObj.Type)
+			}
+			if isPrimitiveTypeValid(typeObj.Type) {
+				continue
+			}
+			// Must be reference type
+			if _, exist := t[typeObj.typeName()]; !exist {
+				return fmt.Errorf("reference type %q is undefined", typeObj.Type)
+			}
+			if !typedDataReferenceTypeRegexp.MatchString(typeObj.Type) {
+				return fmt.Errorf("unknown reference type %q", typeObj.Type)
+			}
+		}
+	}
+	return nil
+}
+
+// Checks if the primitive value is valid
+func isPrimitiveTypeValid(primitiveType string) bool {
+	if primitiveType == "address" ||
+		primitiveType == "address[]" ||
+		primitiveType == "bool" ||
+		primitiveType == "bool[]" ||
+		primitiveType == "string" ||
+		primitiveType == "string[]" ||
+		primitiveType == "bytes" ||
+		primitiveType == "bytes[]" ||
+		primitiveType == "int" ||
+		primitiveType == "int[]" ||
+		primitiveType == "uint" ||
+		primitiveType == "uint[]" {
+		return true
+	}
+	// For 'bytesN', 'bytesN[]', we allow N from 1 to 32
+	for n := 1; n <= 32; n++ {
+		// e.g. 'bytes28' or 'bytes28[]'
+		if primitiveType == fmt.Sprintf("bytes%d", n) || primitiveType == fmt.Sprintf("bytes%d[]", n) {
+			return true
+		}
+	}
+	// For 'intN','intN[]' and 'uintN','uintN[]' we allow N in increments of 8, from 8 up to 256
+	for n := 8; n <= 256; n += 8 {
+		if primitiveType == fmt.Sprintf("int%d", n) || primitiveType == fmt.Sprintf("int%d[]", n) {
+			return true
+		}
+		if primitiveType == fmt.Sprintf("uint%d", n) || primitiveType == fmt.Sprintf("uint%d[]", n) {
+			return true
+		}
+	}
+	return false
+}
+
+// validate checks if the given domain is valid, i.e. contains at least
+// the minimum viable keys and values
+func (domain *TypedDataDomain) validate() error {
+	if domain.ChainId == nil && len(domain.Name) == 0 && len(domain.Version) == 0 && len(domain.VerifyingContract) == 0 && len(domain.Salt) == 0 {
+		return errors.New("domain is undefined")
+	}
+
+	return nil
+}
+
+// Map is a helper function to generate a map version of the domain
+func (domain *TypedDataDomain) Map() map[string]interface{} {
+	dataMap := map[string]interface{}{}
+
+	if domain.ChainId != nil {
+		dataMap["chainId"] = domain.ChainId
+	}
+
+	if len(domain.Name) > 0 {
+		dataMap["name"] = domain.Name
+	}
+
+	if len(domain.Version) > 0 {
+		dataMap["version"] = domain.Version
+	}
+
+	if len(domain.VerifyingContract) > 0 {
+		dataMap["verifyingContract"] = domain.VerifyingContract
+	}
+
+	if len(domain.Salt) > 0 {
+		dataMap["salt"] = domain.Salt
+	}
+	return dataMap
+}
+
+// NameValueType is a very simple struct with Name, Value and Type. It's meant for simple
+// json structures used to communicate signing-info about typed data with the UI
+type NameValueType struct {
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
+	Typ   string      `json:"type"`
+}
+
+// Pprint returns a pretty-printed version of nvt
+func (nvt *NameValueType) Pprint(depth int) string {
+	output := bytes.Buffer{}
+	output.WriteString(strings.Repeat("\u00a0", depth*2))
+	output.WriteString(fmt.Sprintf("%s [%s]: ", nvt.Name, nvt.Typ))
+	if nvts, ok := nvt.Value.([]*NameValueType); ok {
+		output.WriteString("\n")
+		for _, next := range nvts {
+			sublevel := next.Pprint(depth + 1)
+			output.WriteString(sublevel)
+		}
+	} else {
+		if nvt.Value != nil {
+			output.WriteString(fmt.Sprintf("%q\n", nvt.Value))
+		} else {
+			output.WriteString("\n")
+		}
+	}
+	return output.String()
+}

--- a/signer/core/eip712/types_test.go
+++ b/signer/core/eip712/types_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eip712
+
+import "testing"
+
+func TestIsPrimitive(t *testing.T) {
+	// Expected positives
+	for i, tc := range []string{
+		"int24", "int24[]", "uint88", "uint88[]", "uint", "uint[]", "int256", "int256[]",
+		"uint96", "uint96[]", "int96", "int96[]", "bytes17[]", "bytes17",
+	} {
+		if !isPrimitiveTypeValid(tc) {
+			t.Errorf("test %d: expected '%v' to be a valid primitive", i, tc)
+		}
+	}
+	// Expected negatives
+	for i, tc := range []string{
+		"int257", "int257[]", "uint88 ", "uint88 []", "uint257", "uint-1[]",
+		"uint0", "uint0[]", "int95", "int95[]", "uint1", "uint1[]", "bytes33[]", "bytess",
+	} {
+		if isPrimitiveTypeValid(tc) {
+			t.Errorf("test %d: expected '%v' to not be a valid primitive", i, tc)
+		}
+	}
+}

--- a/suave/cstore/engine.go
+++ b/suave/cstore/engine.go
@@ -65,8 +65,8 @@ type CStoreEngine struct {
 	storage        ConfidentialStorageBackend
 	transportTopic StoreTransportTopic
 
-	daSigner    DASigner
-	chainSigner ChainSigner
+	daSigner DASigner
+	// chainSigner ChainSigner
 
 	storeUUID      uuid.UUID
 	localAddresses map[common.Address]struct{}
@@ -83,7 +83,7 @@ func NewEngine(backend ConfidentialStorageBackend, transportTopic StoreTransport
 		storage:        backend,
 		transportTopic: transportTopic,
 		daSigner:       daSigner,
-		chainSigner:    chainSigner,
+		// chainSigner:    chainSigner,
 		storeUUID:      uuid.New(),
 		localAddresses: localAddresses,
 	}
@@ -262,10 +262,12 @@ func (e *CStoreEngine) Finalize(tx *types.Transaction, newRecords map[suave.Data
 		StoreUUID:   e.storeUUID,
 	}
 
-	if _, sigErr := e.chainSigner.Sender(tx); sigErr != nil {
-		log.Info("confidential engine: refusing to send writes based on unsigned transaction", "hash", tx.Hash().Hex(), "err", sigErr)
-		return suave.ErrUnsignedFinalize
-	}
+	/*
+		if _, sigErr := e.chainSigner.Sender(tx); sigErr != nil {
+			log.Info("confidential engine: refusing to send writes based on unsigned transaction", "hash", tx.Hash().Hex(), "err", sigErr)
+			return suave.ErrUnsignedFinalize
+		}
+	*/
 
 	msgBytes, err := SerializeDAMessage(&pwMsg)
 	if err != nil {
@@ -317,10 +319,12 @@ func (e *CStoreEngine) NewMessage(message DAMessage) error {
 		log.Info("Confidential engine: message is spoofing our storeUUID, processing anyway", "message", message)
 	}
 
-	_, err = e.chainSigner.Sender(message.SourceTx)
-	if err != nil {
-		return fmt.Errorf("confidential engine: source tx for message is not signed properly: %w", err)
-	}
+	/*
+		_, err = e.chainSigner.Sender(message.SourceTx)
+		if err != nil {
+			return fmt.Errorf("confidential engine: source tx for message is not signed properly: %w", err)
+		}
+	*/
 
 	// TODO: check if message.SourceTx is valid and insert it into the mempool!
 
@@ -367,11 +371,13 @@ func (e *CStoreEngine) NewMessage(message DAMessage) error {
 			return fmt.Errorf("confidential engine: caller %x not allowed on record %x", sw.Caller, sw.DataRecord.Id)
 		}
 
-		// TODO: move to types.Sender()
-		_, err = e.chainSigner.Sender(sw.DataRecord.CreationTx)
-		if err != nil {
-			return fmt.Errorf("confidential engine: creation tx for record id %x is not signed properly: %w", sw.DataRecord.Id, err)
-		}
+		/*
+			// TODO: move to types.Sender()
+			_, err = e.chainSigner.Sender(sw.DataRecord.CreationTx)
+			if err != nil {
+				return fmt.Errorf("confidential engine: creation tx for record id %x is not signed properly: %w", sw.DataRecord.Id, err)
+			}
+		*/
 	}
 
 	for _, sw := range message.StoreWrites {

--- a/suave/e2e/workflow_test.go
+++ b/suave/e2e/workflow_test.go
@@ -1569,7 +1569,7 @@ func (f *framework) testHttpRelayer(handler handlerFunc) string {
 }
 
 func (f *framework) NewSDKClient() *sdk.Client {
-	return sdk.NewClient(f.suethSrv.RPCNode(), testKey, f.KettleAddress())
+	return sdk.NewClient(f.suethSrv.RPCNode(), testKey, f.KettleAddress()).WithEIP712()
 }
 
 func (f *framework) ConfidentialStoreBackend() cstore.ConfidentialStorageBackend {

--- a/suave/sdk/sdk.go
+++ b/suave/sdk/sdk.go
@@ -98,7 +98,7 @@ func (c *Contract) SendTransaction(method string, args []interface{}, confidenti
 	}
 	if c.client.useEIP712 {
 		record.ChainID = signer.ChainID()
-		record.Envelope = true
+		record.IsEIP712 = true
 	}
 
 	computeRequest, err := types.SignTx(types.NewTx(&types.ConfidentialComputeRequest{


### PR DESCRIPTION
## 📝 Summary

This PR introduces CCRs that are signed with EIP-712 signatures. It introduces two changes:

- A new `signer/core/eip712` package with the `EIP-712` logic copied from `signer/core/apitypes` which due to some dependencies of the package `types` was not possible to use without a circular dependency. So, I copied to the new package only the core primitives.
- A new field `Envelope` in the `ConfidentialComputeRequest` object. If the field `Envelope` is not set, we use the [`eip-2718`](https://eips.ethereum.org/EIPS/eip-2718) rules to generate the signing hash. If the field `Envelope` is set, we generate the signing hash as an `EIP-712` envelope.

All the tests in e2e are using by default the new EIP-712 signing scheme.
 
## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
