### PR TITLE
Add net namespace to suave-dev

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -541,7 +541,7 @@ func prepareSuaveDev(ctx *cli.Context) error {
 		utils.HTTPVirtualHostsFlag.Name:  "*",
 		utils.HTTPCORSDomainFlag.Name:    "*",
 		utils.HTTPListenAddrFlag.Name:    "0.0.0.0",
-		utils.HTTPApiFlag.Name:           "suavex,debug,suavey,eth",
+		utils.HTTPApiFlag.Name:           "suavex,debug,suavey,eth,net,txpool",
 		utils.WSEnabledFlag.Name:         "true",
 		utils.WSAllowedOriginsFlag.Name:  "*",
 		utils.WSListenAddrFlag.Name:      "0.0.0.0",


### PR DESCRIPTION
## 📝 Summary

Enable 'net' namespace in 'suave-dev'.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

* [x] I have seen and agree to CONTRIBUTING.md
