### PR TITLE
Add new bytecode size + some working tests

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -353,9 +353,9 @@ func TestStateProcessorErrors(t *testing.T) {
 		}{
 			{ // ErrMaxInitCodeSizeExceeded
 				txs: []*types.Transaction{
-					mkDynamicCreationTx(0, 500000, common.Big0, misc.CalcBaseFee(config, genesis.Header()), tooBigInitCode[:]),
+					mkDynamicCreationTx(0, 585476, common.Big0, misc.CalcBaseFee(config, genesis.Header()), tooBigInitCode[:]),
 				},
-				want: "could not apply tx 0 [0x832b54a6c3359474a9f504b1003b2cc1b6fcaa18e4ef369eb45b5d40dad6378f]: max initcode size exceeded: code size 49153 limit 49152",
+				want: "could not apply tx 0 [0xd40e36a40cae39254ae0bdc42906662cfdd9d5032df247edd03b32974e42851b]: max initcode size exceeded: code size 131071 limit 131070",
 			},
 			{ // ErrIntrinsicGas: Not enough gas to cover init code
 				txs: []*types.Transaction{

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -115,20 +115,17 @@ var createGasTests = []struct {
 	gasUsed    uint64
 	minimumGas uint64
 }{
-	// legacy create(0, 0, 0xc000) without 3860 used
-	{"0x61C00060006000f0" + "600052" + "60206000F3", false, 41237, 41237},
-	// legacy create(0, 0, 0xc000) _with_ 3860
-	{"0x61C00060006000f0" + "600052" + "60206000F3", true, 44309, 44309},
-	// create2(0, 0, 0xc001, 0) without 3860
-	{"0x600061C00160006000f5" + "600052" + "60206000F3", false, 50471, 50471},
-	// create2(0, 0, 0xc001, 0) (too large), with 3860
-	{"0x600061C00160006000f5" + "600052" + "60206000F3", true, 32012, 100_000},
-	// create2(0, 0, 0xc000, 0)
-	// This case is trying to deploy code at (within) the limit
-	{"0x600061C00060006000f5" + "600052" + "60206000F3", true, 53528, 53528},
-	// create2(0, 0, 0xc001, 0)
-	// This case is trying to deploy code exceeding the limit
-	{"0x600061C00160006000f5" + "600052" + "60206000F3", true, 32024, 100000},
+	// legacy create(0, 0, 0xFFFF) without 3860 used
+	{"0x61FFFF60006000f0" + "600052" + "60206000F3", false, 46357, 46357},
+	// legacy create(0, 0, 0xFFFF) _with_ 3860
+	{"0x61FFFF60006000f0" + "600052" + "60206000F3", true, 50453, 50453},
+	// create2(0, 0, 0xFFFF, 0) without 3860
+	{"0x600061FFFF60006000f5" + "600052" + "60206000F3", false, 58648, 58648},
+	// create2(0, 0, 0xFFFE, 0)
+	// This case is trying to deploy code at (within) the limit with 3860
+	{"0x600061FFFF60006000f5" + "600052" + "60206000F3", true, 62744, 62744},
+	// create2(0, 0, 0xFFFF, 0) (too large) with 3860
+	//{"0x600061FFFF60006000f5" + "600052" + "60206000F3", true, 62744, 100_000},
 }
 
 func TestCreateGas(t *testing.T) {

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -115,17 +115,20 @@ var createGasTests = []struct {
 	gasUsed    uint64
 	minimumGas uint64
 }{
-	// legacy create(0, 0, 0xFFFF) without 3860 used
-	{"0x61FFFF60006000f0" + "600052" + "60206000F3", false, 46357, 46357},
-	// legacy create(0, 0, 0xFFFF) _with_ 3860
-	{"0x61FFFF60006000f0" + "600052" + "60206000F3", true, 50453, 50453},
-	// create2(0, 0, 0xFFFF, 0) without 3860
-	{"0x600061FFFF60006000f5" + "600052" + "60206000F3", false, 58648, 58648},
-	// create2(0, 0, 0xFFFE, 0)
-	// This case is trying to deploy code at (within) the limit with 3860
-	{"0x600061FFFF60006000f5" + "600052" + "60206000F3", true, 62744, 62744},
-	// create2(0, 0, 0xFFFF, 0) (too large) with 3860
-	//{"0x600061FFFF60006000f5" + "600052" + "60206000F3", true, 62744, 100_000},
+	// legacy create(0, 0, 0xc000) without 3860 used
+	{"0x61C00060006000f0" + "600052" + "60206000F3", false, 41237, 41237},
+	// legacy create(0, 0, 0xc000) _with_ 3860
+	{"0x61C00060006000f0" + "600052" + "60206000F3", true, 44309, 44309},
+	// create2(0, 0, 0xc001, 0) without 3860
+	{"0x600061C00160006000f5" + "600052" + "60206000F3", false, 50471, 50471},
+	// create2(0, 0, 0xc001, 0) (too large), with 3860
+	{"0x60006201FFFE60006000f5" + "600052" + "60206000F3", true, 53545, 100_000},
+	// create2(0, 0, 0xc000, 0)
+	// This case is trying to deploy code at (within) the limit
+	{"0x600061C00060006000f5" + "600052" + "60206000F3", true, 53528, 53528},
+	// create2(0, 0, 0x01FFFE, 0)
+	// This case is trying to deploy code exceeding the limit
+	{"0x60006201FFFE60006000f5" + "600052" + "60206000F3", true, 62744, 100000},
 }
 
 func TestCreateGas(t *testing.T) {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -124,7 +124,7 @@ const (
 	DefaultElasticityMultiplier     = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	InitialBaseFee                  = 1000000000 // Initial base fee for EIP-1559 blocks.
 
-	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
+	MaxCodeSize     = 65535           // Maximum bytecode to permit for a contract
 	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
 
 	// Precompiled contract gas prices


### PR DESCRIPTION
## 📝 Summary

Changes the contract bytecode size limit to `65535` per request from users.

## 📚 References

This causes some issues with the gas tests (and elsewhere) which @ferranbt has kindly agreed to fix.

---

* [x] I have seen and agree to CONTRIBUTING.md
