### PR TITLE
Add gauge metrics for redis cstore items

### DIFF
--- a/.github/workflows/integration-examples.yml
+++ b/.github/workflows/integration-examples.yml
@@ -23,14 +23,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run dev environment
-        run: docker-compose -f ./suave/e2e/docker-compose.yml up -d --build
+        run: docker compose -f ./suave/e2e/docker-compose.yml up -d --build
 
       - name: Check out suapp-examples
         uses: actions/checkout@v2
         with:
           repository: flashbots/suapp-examples
           path: suapp-examples
-      
+
       - name: Build suapp-examples
         run: |
           cd suapp-examples

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ suavedevtools:
 	go run ./suave/gen/main.go -write
 
 devnet-up:
-	docker-compose -f ./suave/devenv/docker-compose.yml up -d --build
+	docker compose -f ./suave/devenv/docker-compose.yml up -d --build
 
 devnet-down:
-	docker-compose -f ./suave/devenv/docker-compose.yml down
+	docker compose -f ./suave/devenv/docker-compose.yml down
 
 fmt-contracts:
 	cd suave && forge fmt

--- a/suave/cstore/redis_store_backend_test.go
+++ b/suave/cstore/redis_store_backend_test.go
@@ -82,3 +82,19 @@ func TestRedis_TTL_MultipleEntries_SameIndex(t *testing.T) {
 	require.Len(t, vals, 1)
 	require.Equal(t, record2, vals[0])
 }
+
+func TestRedis_Count(t *testing.T) {
+	store, err := NewRedisStoreBackend("", 2*time.Second)
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		record := suave.DataRecord{
+			Id:                  suave.RandomDataRecordId(),
+			Version:             "a",
+			DecryptionCondition: 1,
+		}
+		require.NoError(t, store.InitRecord(record))
+	}
+
+	require.NotZero(t, store.count())
+}


### PR DESCRIPTION
## 📝 Summary

This PR adds a new metric `suave/confstore/items` that returns the number of items in the Redis confidential store.


* [x] I have seen and agree to CONTRIBUTING.md
