### PR TITLE
End builder session on a New Block

### DIFF
--- a/suave/builder/builder.go
+++ b/suave/builder/builder.go
@@ -85,6 +85,4 @@ func (b *builder) AddTransaction(txn *types.Transaction) (*types.SimulateTransac
 
 func (b *builder) Terminate() {
 	b.cancelFunc()
-	b.txns = nil
-	b.receipts = nil
 }

--- a/suave/builder/session_manager.go
+++ b/suave/builder/session_manager.go
@@ -198,7 +198,7 @@ func (s *SessionManager) listenForChainHeadEvents() {
 	}
 }
 
-func (s *SessionManager) terminateAllSessions() {
+func (s *SessionManager) terminateAllSessions() error {
 	s.sessionsLock.Lock()
 	defer s.sessionsLock.Unlock()
 
@@ -215,9 +215,10 @@ func (s *SessionManager) terminateAllSessions() {
 		select {
 		case s.sem <- struct{}{}:
 		default:
-			panic("released more sessions than are open")
+			return fmt.Errorf("released more sessions than are open")
 		}
 	}
+	return nil
 }
 
 func (s *SessionManager) Close() {


### PR DESCRIPTION
#167 

Implement a mechanism to end builder sessions when a new block arrives, to avoid simulations on invalid states.

- `SessionManager` now subscribes to `ChainHeadEvent`
- On receiving a new block event, all active sessions are terminated.
- Added checks to prevent new sessions from being created after `SessionManager` is closed.
- Added a `Terminate` method to `builder` for clean session ending.
- Added tests.