### PR TITLE
Remove listing of every key inside Redis error logs

### DIFF
--- a/suave/cstore/redis_store_backend.go
+++ b/suave/cstore/redis_store_backend.go
@@ -185,7 +185,7 @@ func (r *RedisStoreBackend) Retrieve(record suave.DataRecord, caller common.Addr
 	storeKey := formatRecordValueKey(record.Id, key)
 	data, err := r.client.Get(r.ctx, storeKey).Bytes()
 	if err != nil {
-		return []byte{}, fmt.Errorf("unexpected redis error: %w, %s, %v", err, storeKey, r.client.Keys(context.TODO(), "*").String())
+		return []byte{}, fmt.Errorf("unexpected redis error: %w, %s", err, storeKey)
 	}
 
 	return data, nil


### PR DESCRIPTION
## 📝 Summary

The previous error log listed every key in the confidential store. For contracts that use the confstore heavily this essentially bricks every function that hits this error, because the returning data is so huge it consumes all the gas

* [x] I have seen and agree to CONTRIBUTING.md
