### PR TITLE
fix: Iterate pendingWrites backward to get the last updated value

### DIFF
--- a/suave/cstore/transactional_store.go
+++ b/suave/cstore/transactional_store.go
@@ -82,7 +82,8 @@ func (s *TransactionalStore) Retrieve(dataId suave.DataId, caller common.Address
 
 	s.pendingLock.Lock()
 
-	for _, sw := range s.pendingWrites {
+	for i := len(s.pendingWrites) - 1; i >= 0; i-- {
+		sw := s.pendingWrites[i]
 		if sw.DataRecord.Id == record.Id && sw.Key == key {
 			s.pendingLock.Unlock()
 			return common.CopyBytes(sw.Value), nil


### PR DESCRIPTION
## 📝 Summary

Multiple `Store` operations in a single CCR append the values to `pendingWrites`, which makes it sorted by time ascending. When doing a `Retrieve` the list of `pendingWrites` was iterated from oldest to newest, which means only the first stored value for a given key was ever returned. This PR iterates over `pendingWrites` in reverse so the latest stored value is returned.

---

* [ ] I have seen and agree to CONTRIBUTING.md
